### PR TITLE
Company admin: Validate/Fix customer addresses against company addresses

### DIFF
--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
@@ -882,7 +882,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
         /// Extra address rows themselves are left intact — only their CustomerAddressMapping links are removed.
         /// </summary>
         [HttpPost]
-        public virtual async Task<IActionResult> FixAddresses(int companyId, int[] customerIds)
+        public virtual async Task<IActionResult> FixAddresses(int companyId, string customerIds)
         {
             if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCustomers))
                 return Json(new { success = false, message = "Access denied." });
@@ -891,7 +891,15 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
             if (company == null)
                 return Json(new { success = false, message = "Company not found." });
 
-            if (customerIds == null || customerIds.Length == 0)
+            //customerIds arrives as a single comma-separated field (one form value) to avoid the
+            //default form value-count / model-binding collection limits (1024) on large companies
+            var requestedIds = (customerIds ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(x => int.TryParse(x, out var n) ? n : 0)
+                .Where(n => n > 0)
+                .Distinct()
+                .ToList();
+            if (requestedIds.Count == 0)
                 return Json(new { success = false, message = "No customers were selected to fix." });
 
             var canonical = await GetCompanyCanonicalAddressesAsync(company.Id);
@@ -906,7 +914,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
             var removedMappings = 0;
             var addedAddresses = 0;
 
-            foreach (var customerId in customerIds.Distinct())
+            foreach (var customerId in requestedIds)
             {
                 if (!validCustomerIds.Contains(customerId))
                     continue;

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
@@ -752,5 +752,218 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
         }
 
         #endregion
+
+        #region Address validation / fix
+
+        /// <summary>
+        /// Builds a content-based comparison key for an address so customer addresses can be matched
+        /// against the company's canonical addresses regardless of their Id. Mirrors the fields copied
+        /// by IAddressService.CloneAddress (the same fields used when company addresses are cloned to a
+        /// customer at registration), so a correctly cloned address yields an identical key.
+        /// </summary>
+        private static string GetAddressKey(Nop.Core.Domain.Common.Address a)
+        {
+            string s(string v) => (v ?? string.Empty).Trim().ToLowerInvariant();
+            return string.Join("|",
+                s(a.FirstName), s(a.LastName), s(a.Email), s(a.Company),
+                a.CountryId ?? 0, a.StateProvinceId ?? 0,
+                s(a.County), s(a.City), s(a.Address1), s(a.Address2),
+                s(a.ZipPostalCode), s(a.PhoneNumber), s(a.FaxNumber),
+                s(a.CustomAttributes));
+        }
+
+        /// <summary>
+        /// Human-readable one-line summary of an address for display in the validation results table.
+        /// </summary>
+        private static string GetAddressSummary(Nop.Core.Domain.Common.Address a)
+        {
+            var parts = new List<string>();
+            var name = $"{a.FirstName} {a.LastName}".Trim();
+            if (!string.IsNullOrWhiteSpace(name))
+                parts.Add(name);
+            if (!string.IsNullOrWhiteSpace(a.Address1))
+                parts.Add(a.Address1);
+            var cityZip = $"{a.City} {a.ZipPostalCode}".Trim();
+            if (!string.IsNullOrWhiteSpace(cityZip))
+                parts.Add(cityZip);
+            if (!string.IsNullOrWhiteSpace(a.Email))
+                parts.Add(a.Email);
+            var summary = string.Join(", ", parts);
+            return string.IsNullOrWhiteSpace(summary) ? $"(empty address #{a.Id})" : summary;
+        }
+
+        /// <summary>
+        /// Builds the company's canonical set of addresses keyed by content (one entry per unique
+        /// address). Used both to detect mismatches and as the source for cloning missing addresses
+        /// back onto a customer.
+        /// </summary>
+        private async Task<Dictionary<string, Nop.Core.Domain.Common.Address>> GetCompanyCanonicalAddressesAsync(int companyId)
+        {
+            var companyAddresses = await _companyAddressService.GetCompanyAddressesByCompanyIdAsync(companyId);
+            var canonical = new Dictionary<string, Nop.Core.Domain.Common.Address>();
+            foreach (var ca in companyAddresses)
+            {
+                var addr = await _addressService.GetAddressByIdAsync(ca.AddressId);
+                if (addr == null)
+                    continue;
+                var key = GetAddressKey(addr);
+                if (!canonical.ContainsKey(key))
+                    canonical[key] = addr;
+            }
+
+            return canonical;
+        }
+
+        /// <summary>
+        /// Scans every company-associated customer and reports those whose address list contains one or
+        /// more addresses that are NOT among the company's addresses (i.e. they don't have exactly the
+        /// same set of addresses as the company). Read-only — makes no changes.
+        /// </summary>
+        [HttpPost]
+        public virtual async Task<IActionResult> ValidateAddresses(int companyId)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCustomers))
+                return Json(new { success = false, message = "Access denied." });
+
+            var company = await _companyService.GetCompanyByIdAsync(companyId);
+            if (company == null)
+                return Json(new { success = false, message = "Company not found." });
+
+            var canonical = await GetCompanyCanonicalAddressesAsync(company.Id);
+            if (canonical.Count == 0)
+                return Json(new { success = false, message = "This company has no addresses defined. Add at least one company address before validating — otherwise every customer address would be treated as invalid." });
+
+            var companyCustomers = await _companyService.GetCompanyCustomersByCompanyIdAsync(company.Id, showHidden: true);
+            var flagged = new List<object>();
+            var totalCustomers = 0;
+
+            foreach (var cc in companyCustomers)
+            {
+                var customer = await _customerService.GetCustomerByIdAsync(cc.CustomerId);
+                if (customer == null)
+                    continue;
+                totalCustomers++;
+
+                var addresses = await _customerService.GetAddressesByCustomerIdAsync(customer.Id);
+                var presentKeys = new HashSet<string>(addresses.Select(GetAddressKey));
+
+                var extras = addresses.Where(a => !canonical.ContainsKey(GetAddressKey(a))).ToList();
+                var missing = canonical.Where(kv => !presentKeys.Contains(kv.Key)).Select(kv => kv.Value).ToList();
+
+                if (extras.Any() || missing.Any())
+                {
+                    flagged.Add(new
+                    {
+                        customerId = customer.Id,
+                        name = await _customerService.GetCustomerFullNameAsync(customer),
+                        email = customer.Email,
+                        extras = extras.Select(a => new { id = a.Id, summary = GetAddressSummary(a) }).ToList(),
+                        missing = missing.Select(a => new { summary = GetAddressSummary(a) }).ToList()
+                    });
+                }
+            }
+
+            return Json(new
+            {
+                success = true,
+                companyAddressCount = canonical.Count,
+                totalCustomers,
+                flaggedCount = flagged.Count,
+                flagged
+            });
+        }
+
+        /// <summary>
+        /// Brings the supplied (already-validated and displayed) customers into exact agreement with the
+        /// company's addresses: it unlinks every customer-address mapping whose address is NOT one of the
+        /// company's addresses, and clones any missing company addresses onto the customer (the same way
+        /// they are copied at registration). Both sets are recomputed server-side (the client list is not
+        /// trusted). Billing/shipping pointers that ended up cleared are repointed to a company address.
+        /// Extra address rows themselves are left intact — only their CustomerAddressMapping links are removed.
+        /// </summary>
+        [HttpPost]
+        public virtual async Task<IActionResult> FixAddresses(int companyId, int[] customerIds)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCustomers))
+                return Json(new { success = false, message = "Access denied." });
+
+            var company = await _companyService.GetCompanyByIdAsync(companyId);
+            if (company == null)
+                return Json(new { success = false, message = "Company not found." });
+
+            if (customerIds == null || customerIds.Length == 0)
+                return Json(new { success = false, message = "No customers were selected to fix." });
+
+            var canonical = await GetCompanyCanonicalAddressesAsync(company.Id);
+            if (canonical.Count == 0)
+                return Json(new { success = false, message = "This company has no addresses defined. Nothing to validate against." });
+
+            //only ever touch customers that actually belong to this company
+            var validCustomerIds = (await _companyService.GetCompanyCustomersByCompanyIdAsync(company.Id, showHidden: true))
+                .Select(cc => cc.CustomerId).ToHashSet();
+
+            var fixedCustomers = 0;
+            var removedMappings = 0;
+            var addedAddresses = 0;
+
+            foreach (var customerId in customerIds.Distinct())
+            {
+                if (!validCustomerIds.Contains(customerId))
+                    continue;
+
+                var customer = await _customerService.GetCustomerByIdAsync(customerId);
+                if (customer == null)
+                    continue;
+
+                var addresses = await _customerService.GetAddressesByCustomerIdAsync(customer.Id);
+                var presentKeys = new HashSet<string>(addresses.Select(GetAddressKey));
+
+                var extras = addresses.Where(a => !canonical.ContainsKey(GetAddressKey(a))).ToList();
+                var missing = canonical.Where(kv => !presentKeys.Contains(kv.Key)).Select(kv => kv.Value).ToList();
+
+                if (!extras.Any() && !missing.Any())
+                    continue;
+
+                //remove extras (RemoveCustomerAddressAsync also nulls Billing/ShippingAddressId in memory if matched)
+                foreach (var extra in extras)
+                {
+                    await _customerService.RemoveCustomerAddressAsync(customer, extra);
+                    removedMappings++;
+                }
+
+                //backfill missing company addresses by cloning them onto the customer (same as registration)
+                foreach (var companyAddress in missing)
+                {
+                    var clone = _addressService.CloneAddress(companyAddress);
+                    clone.CreatedOnUtc = DateTime.UtcNow;
+                    await _addressService.InsertAddressAsync(clone);
+                    await _customerService.InsertCustomerAddressAsync(customer, clone);
+                    addedAddresses++;
+                }
+
+                //ensure billing/shipping point at one of the company addresses now mapped to the customer
+                var companyMapped = (await _customerService.GetAddressesByCustomerIdAsync(customer.Id))
+                    .Where(a => canonical.ContainsKey(GetAddressKey(a))).ToList();
+                var fallbackId = companyMapped.Select(a => (int?)a.Id).FirstOrDefault();
+                if ((customer.BillingAddressId == null || customer.BillingAddressId == 0) && fallbackId.HasValue)
+                    customer.BillingAddressId = fallbackId;
+                if ((customer.ShippingAddressId == null || customer.ShippingAddressId == 0) && fallbackId.HasValue)
+                    customer.ShippingAddressId = fallbackId;
+
+                await _customerService.UpdateCustomerAsync(customer);
+                fixedCustomers++;
+            }
+
+            return Json(new
+            {
+                success = true,
+                message = $"Fixed {fixedCustomers} customer(s); removed {removedMappings} extra link(s), added {addedAddresses} missing address(es).",
+                fixedCustomers,
+                removedMappings,
+                addedAddresses
+            });
+        }
+
+        #endregion
     }
 }

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Views/Company/_CreateOrUpdate.Addresses.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Views/Company/_CreateOrUpdate.Addresses.cshtml
@@ -60,6 +60,162 @@
                 }
     </script>
 </div>
+
+<div class="card-body" id="company-address-validation-block">
+    <div class="form-text-row" style="margin-bottom: 10px;">
+        <strong>Address consistency check.</strong>
+        Every customer associated with this company should have exactly the same addresses as the
+        company (they are copied to each customer at registration). Use <em>Validate</em> to find
+        customers whose addresses don't match the company's — either extra addresses that aren't the
+        company's, or company addresses they're missing. Use <em>Fix</em> to unlink the extra addresses
+        and add (clone) the missing company addresses to the listed customers, so they end up with
+        exactly the company's set.
+    </div>
+
+    <button type="button" class="btn btn-warning" id="validate-company-addresses-btn"
+            title="Scans every customer linked to this company and lists those whose addresses don't exactly match the company's — extra addresses that aren't the company's and/or company addresses they're missing. Read-only — makes no changes.">
+        <i class="fas fa-clipboard-check"></i>
+        Validate
+    </button>
+    <button type="button" class="btn btn-danger" id="fix-company-addresses-btn" style="display: none;"
+            title="For the customers shown in the table below: unlinks every address that is not one of the company's addresses, and clones any missing company addresses onto the customer. Extra address records are kept (only the customer-to-address links are removed); missing ones are added as new copies. Billing/shipping is repointed to a company address when needed.">
+        <i class="fas fa-wrench"></i>
+        Fix shown customers
+    </button>
+
+    <div id="validate-company-addresses-status" style="margin-top: 10px;"></div>
+
+    <div id="validate-company-addresses-results" style="display: none; margin-top: 10px;">
+        <table class="table table-bordered table-hover" id="validate-company-addresses-table">
+            <thead>
+                <tr>
+                    <th>Customer</th>
+                    <th>Email</th>
+                    <th>Extra addresses to remove</th>
+                    <th>Missing addresses to add</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function () {
+        var companyId = @Model.Id;
+        var $validateBtn = $('#validate-company-addresses-btn');
+        var $fixBtn = $('#fix-company-addresses-btn');
+        var $status = $('#validate-company-addresses-status');
+        var $results = $('#validate-company-addresses-results');
+        var $tbody = $('#validate-company-addresses-table tbody');
+        var flaggedCustomerIds = [];
+
+        function antiForgeryToken() {
+            return $('input[name="__RequestVerificationToken"]').first().val();
+        }
+
+        $validateBtn.on('click', function () {
+            $validateBtn.prop('disabled', true);
+            $fixBtn.hide();
+            $results.hide();
+            $tbody.empty();
+            flaggedCustomerIds = [];
+            $status.html('<span class="text-muted">Validating…</span>');
+
+            $.ajax({
+                cache: false,
+                type: 'POST',
+                url: '@Url.Action("ValidateAddresses", "Company")',
+                data: { companyId: companyId, __RequestVerificationToken: antiForgeryToken() },
+                dataType: 'json',
+                success: function (response) {
+                    if (!response.success) {
+                        $status.html('<span class="text-danger">' + response.message + '</span>');
+                        return;
+                    }
+
+                    if (response.flaggedCount === 0) {
+                        $status.html('<span class="text-success">All ' + response.totalCustomers +
+                            ' company customer(s) have exactly the company\'s ' + response.companyAddressCount +
+                            ' address(es). Nothing to fix.</span>');
+                        return;
+                    }
+
+                    function addressListCell(items) {
+                        if (!items || items.length === 0)
+                            return $('<td class="text-center"></td>').text('—');
+                        var list = $('<ul style="margin:0;padding-left:18px;"></ul>');
+                        $.each(items, function (j, addr) {
+                            list.append($('<li></li>').text(addr.summary));
+                        });
+                        return $('<td></td>').append(list);
+                    }
+
+                    $.each(response.flagged, function (i, c) {
+                        flaggedCustomerIds.push(c.customerId);
+                        var $row = $('<tr></tr>');
+                        $row.append($('<td></td>').text(c.name || '(no name)'));
+                        $row.append($('<td></td>').text(c.email || ''));
+                        $row.append(addressListCell(c.extras));
+                        $row.append(addressListCell(c.missing));
+                        $tbody.append($row);
+                    });
+
+                    $status.html('<span class="text-danger">' + response.flaggedCount + ' of ' +
+                        response.totalCustomers + ' company customer(s) don\'t match the company\'s ' +
+                        response.companyAddressCount + ' address(es).</span>');
+                    $results.show();
+                    $fixBtn.show().prop('disabled', false);
+                },
+                error: function () {
+                    $status.html('<span class="text-danger">Validation failed. Please try again.</span>');
+                },
+                complete: function () {
+                    $validateBtn.prop('disabled', false);
+                }
+            });
+        });
+
+        $fixBtn.on('click', function () {
+            if (flaggedCustomerIds.length === 0)
+                return;
+            if (!confirm('Update ' + flaggedCustomerIds.length +
+                ' customer(s) to exactly match the company\'s addresses (remove extras, add missing)? This cannot be undone.'))
+                return;
+
+            $fixBtn.prop('disabled', true);
+            $status.html('<span class="text-muted">Fixing…</span>');
+
+            $.ajax({
+                cache: false,
+                type: 'POST',
+                traditional: true,
+                url: '@Url.Action("FixAddresses", "Company")',
+                data: { companyId: companyId, customerIds: flaggedCustomerIds, __RequestVerificationToken: antiForgeryToken() },
+                dataType: 'json',
+                success: function (response) {
+                    if (!response.success) {
+                        $status.html('<span class="text-danger">' + response.message + '</span>');
+                        $fixBtn.prop('disabled', false);
+                        return;
+                    }
+                    $status.html('<span class="text-success">' + response.message + ' Re-validating…</span>');
+                    $tbody.empty();
+                    $results.hide();
+                    $fixBtn.hide();
+                    flaggedCustomerIds = [];
+                    //re-run validation to confirm the result
+                    $validateBtn.trigger('click');
+                },
+                error: function () {
+                    $status.html('<span class="text-danger">Fix failed. Please try again.</span>');
+                    $fixBtn.prop('disabled', false);
+                }
+            });
+        });
+    });
+</script>
+
  <div class="card-body">
         <button type="button" class="btn btn-primary" onclick="location.href = '@Url.Action("AddressCreate", new { customerId = Model.Id })'">
             @T("Admin.Customers.Customers.Addresses.AddButton")

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Addresses.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Addresses.cshtml
@@ -60,6 +60,162 @@
                 }
     </script>
 </div>
+
+<div class="card-body" id="company-address-validation-block">
+    <div class="form-text-row" style="margin-bottom: 10px;">
+        <strong>Address consistency check.</strong>
+        Every customer associated with this company should have exactly the same addresses as the
+        company (they are copied to each customer at registration). Use <em>Validate</em> to find
+        customers whose addresses don't match the company's — either extra addresses that aren't the
+        company's, or company addresses they're missing. Use <em>Fix</em> to unlink the extra addresses
+        and add (clone) the missing company addresses to the listed customers, so they end up with
+        exactly the company's set.
+    </div>
+
+    <button type="button" class="btn btn-warning" id="validate-company-addresses-btn"
+            title="Scans every customer linked to this company and lists those whose addresses don't exactly match the company's — extra addresses that aren't the company's and/or company addresses they're missing. Read-only — makes no changes.">
+        <i class="fas fa-clipboard-check"></i>
+        Validate
+    </button>
+    <button type="button" class="btn btn-danger" id="fix-company-addresses-btn" style="display: none;"
+            title="For the customers shown in the table below: unlinks every address that is not one of the company's addresses, and clones any missing company addresses onto the customer. Extra address records are kept (only the customer-to-address links are removed); missing ones are added as new copies. Billing/shipping is repointed to a company address when needed.">
+        <i class="fas fa-wrench"></i>
+        Fix shown customers
+    </button>
+
+    <div id="validate-company-addresses-status" style="margin-top: 10px;"></div>
+
+    <div id="validate-company-addresses-results" style="display: none; margin-top: 10px;">
+        <table class="table table-bordered table-hover" id="validate-company-addresses-table">
+            <thead>
+                <tr>
+                    <th>Customer</th>
+                    <th>Email</th>
+                    <th>Extra addresses to remove</th>
+                    <th>Missing addresses to add</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function () {
+        var companyId = @Model.Id;
+        var $validateBtn = $('#validate-company-addresses-btn');
+        var $fixBtn = $('#fix-company-addresses-btn');
+        var $status = $('#validate-company-addresses-status');
+        var $results = $('#validate-company-addresses-results');
+        var $tbody = $('#validate-company-addresses-table tbody');
+        var flaggedCustomerIds = [];
+
+        function antiForgeryToken() {
+            return $('input[name="__RequestVerificationToken"]').first().val();
+        }
+
+        $validateBtn.on('click', function () {
+            $validateBtn.prop('disabled', true);
+            $fixBtn.hide();
+            $results.hide();
+            $tbody.empty();
+            flaggedCustomerIds = [];
+            $status.html('<span class="text-muted">Validating…</span>');
+
+            $.ajax({
+                cache: false,
+                type: 'POST',
+                url: '@Url.Action("ValidateAddresses", "Company")',
+                data: { companyId: companyId, __RequestVerificationToken: antiForgeryToken() },
+                dataType: 'json',
+                success: function (response) {
+                    if (!response.success) {
+                        $status.html('<span class="text-danger">' + response.message + '</span>');
+                        return;
+                    }
+
+                    if (response.flaggedCount === 0) {
+                        $status.html('<span class="text-success">All ' + response.totalCustomers +
+                            ' company customer(s) have exactly the company\'s ' + response.companyAddressCount +
+                            ' address(es). Nothing to fix.</span>');
+                        return;
+                    }
+
+                    function addressListCell(items) {
+                        if (!items || items.length === 0)
+                            return $('<td class="text-center"></td>').text('—');
+                        var list = $('<ul style="margin:0;padding-left:18px;"></ul>');
+                        $.each(items, function (j, addr) {
+                            list.append($('<li></li>').text(addr.summary));
+                        });
+                        return $('<td></td>').append(list);
+                    }
+
+                    $.each(response.flagged, function (i, c) {
+                        flaggedCustomerIds.push(c.customerId);
+                        var $row = $('<tr></tr>');
+                        $row.append($('<td></td>').text(c.name || '(no name)'));
+                        $row.append($('<td></td>').text(c.email || ''));
+                        $row.append(addressListCell(c.extras));
+                        $row.append(addressListCell(c.missing));
+                        $tbody.append($row);
+                    });
+
+                    $status.html('<span class="text-danger">' + response.flaggedCount + ' of ' +
+                        response.totalCustomers + ' company customer(s) don\'t match the company\'s ' +
+                        response.companyAddressCount + ' address(es).</span>');
+                    $results.show();
+                    $fixBtn.show().prop('disabled', false);
+                },
+                error: function () {
+                    $status.html('<span class="text-danger">Validation failed. Please try again.</span>');
+                },
+                complete: function () {
+                    $validateBtn.prop('disabled', false);
+                }
+            });
+        });
+
+        $fixBtn.on('click', function () {
+            if (flaggedCustomerIds.length === 0)
+                return;
+            if (!confirm('Update ' + flaggedCustomerIds.length +
+                ' customer(s) to exactly match the company\'s addresses (remove extras, add missing)? This cannot be undone.'))
+                return;
+
+            $fixBtn.prop('disabled', true);
+            $status.html('<span class="text-muted">Fixing…</span>');
+
+            $.ajax({
+                cache: false,
+                type: 'POST',
+                traditional: true,
+                url: '@Url.Action("FixAddresses", "Company")',
+                data: { companyId: companyId, customerIds: flaggedCustomerIds, __RequestVerificationToken: antiForgeryToken() },
+                dataType: 'json',
+                success: function (response) {
+                    if (!response.success) {
+                        $status.html('<span class="text-danger">' + response.message + '</span>');
+                        $fixBtn.prop('disabled', false);
+                        return;
+                    }
+                    $status.html('<span class="text-success">' + response.message + ' Re-validating…</span>');
+                    $tbody.empty();
+                    $results.hide();
+                    $fixBtn.hide();
+                    flaggedCustomerIds = [];
+                    //re-run validation to confirm the result
+                    $validateBtn.trigger('click');
+                },
+                error: function () {
+                    $status.html('<span class="text-danger">Fix failed. Please try again.</span>');
+                    $fixBtn.prop('disabled', false);
+                }
+            });
+        });
+    });
+</script>
+
  <div class="card-body">
         <button type="button" class="btn btn-primary" onclick="location.href = '@Url.Action("AddressCreate", new { companyId = Model.Id })'">
             @T("Admin.Customers.Customers.Addresses.AddButton")

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Addresses.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Addresses.cshtml
@@ -189,9 +189,8 @@
             $.ajax({
                 cache: false,
                 type: 'POST',
-                traditional: true,
                 url: '@Url.Action("FixAddresses", "Company")',
-                data: { companyId: companyId, customerIds: flaggedCustomerIds, __RequestVerificationToken: antiForgeryToken() },
+                data: { companyId: companyId, customerIds: flaggedCustomerIds.join(','), __RequestVerificationToken: antiForgeryToken() },
                 dataType: 'json',
                 success: function (response) {
                     if (!response.success) {


### PR DESCRIPTION
Adds a **Validate** + **Fix** workflow to the Addresses section of the admin Company edit page (Company.Company plugin).

## What it does
- **Validate** (read-only): scans every *active* company-associated customer and lists those whose address set doesn't exactly match the company's — extra addresses that aren't the company's and/or company addresses they're missing. Matching is by address content (the same fields `CloneAddress` copies), not by Id.
- **Fix**: for the shown customers, unlinks extra addresses (only the `CustomerAddressMapping` is removed — the `Address` row is kept, so historical orders, which carry their own cloned snapshot addresses, are unaffected) and clones any missing company addresses onto the customer (same mechanism as registration). Billing/shipping are repointed to a company address only when they were cleared/empty — a valid current pointer is never changed.

## Notes
- Soft-deleted customers are excluded (via `GetCompanyCustomersByCompanyIdAsync`'s `!Deleted` filter).
- Empty-company guard prevents stripping everyone when no company address is defined.
- `customerIds` posted as a single comma field to avoid the form value-count limit on large companies.

## Verified on dev (dev.mysnacks.shop, image 137)
- ServiceTitan (1068 customers): all 1060 active customers consolidated to the single company address with valid billing & shipping; 8 soft-deleted correctly skipped. No errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)