### PR TITLE
CI: image tag {branch}-{sha6}-{run}

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,11 +18,18 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Compute image tag
+        id: meta
+        run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          SHORT_SHA="${GITHUB_SHA:0:6}"
+          echo "tag=${BRANCH}-${SHORT_SHA}-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push container image to registry
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: eisajanyan/nopcommerce:${{ github.run_number }}-${{ github.sha }}
+          tags: eisajanyan/nopcommerce:${{ steps.meta.outputs.tag }}
           file: Dockerfile
           context: .
     


### PR DESCRIPTION
Changes the Docker image tag from `{run_number}-{full_sha}` to `{branch}-{sha6}-{run_number}` (branch slash-sanitized for Docker tag validity). Verified on build #140 → `hotfix-ci-image-tag-860be3-140`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)