### PR TITLE
Enrich OTel server spans with customer/store context

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/TraceEnrichmentStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/TraceEnrichmentStartup.cs
@@ -82,9 +82,11 @@ namespace Nop.Web.Framework.Infrastructure
         }
 
         /// <summary>
-        /// After AuthenticationStartup (500) so the customer is resolved from the
-        /// auth cookie / JWT bearer before we read it.
+        /// After AuthenticationStartup (500) / AuthorizationStartup (600) so the
+        /// customer is resolved, but BEFORE NopMvcStartup (1000) — which registers
+        /// the terminal endpoint middleware; anything at/after 1000 would be added
+        /// past UseEndpoints and never run for matched routes.
         /// </summary>
-        public int Order => 1000;
+        public int Order => 700;
     }
 }

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/TraceEnrichmentStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/TraceEnrichmentStartup.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core;
+using Nop.Core.Infrastructure;
+using Nop.Services.Customers;
+
+namespace Nop.Web.Framework.Infrastructure
+{
+    /// <summary>
+    /// Enriches the OpenTelemetry server span (created by the zero-code .NET
+    /// auto-instrumentation) with the current MySnacks customer/store context, so
+    /// traces in SigNoz can be filtered and correlated by user.
+    /// </summary>
+    /// <remarks>
+    /// No OpenTelemetry SDK is referenced — during a request <see cref="Activity.Current"/>
+    /// IS the ASP.NET Core server span, and <see cref="Activity"/> lives in the BCL.
+    /// Enrichment must never break a request, hence the broad catch.
+    /// <para><c>enduser.id</c> is the nopCommerce CustomerId, which is also the Mixpanel
+    /// distinct_id — a clean join key between traces and product analytics.</para>
+    /// </remarks>
+    public class TraceEnrichmentStartup : INopStartup
+    {
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+        }
+
+        public void Configure(IApplicationBuilder application)
+        {
+            application.Use(async (context, next) =>
+            {
+                await EnrichAsync(context);
+                await next();
+            });
+        }
+
+        protected static async Task EnrichAsync(HttpContext context)
+        {
+            var activity = Activity.Current;
+            if (activity == null)
+                return;
+
+            try
+            {
+                var services = context.RequestServices;
+
+                var workContext = services.GetService<IWorkContext>();
+                var customer = workContext == null ? null : await workContext.GetCurrentCustomerAsync();
+                if (customer != null)
+                {
+                    var customerService = services.GetService<ICustomerService>();
+
+                    activity.SetTag("enduser.id", customer.Id);
+                    activity.SetTag("mysnacks.customer.guid", customer.CustomerGuid);
+
+                    if (customerService != null)
+                    {
+                        activity.SetTag("mysnacks.customer.registered", await customerService.IsRegisteredAsync(customer));
+
+                        var roles = await customerService.GetCustomerRolesAsync(customer);
+                        if (roles.Count > 0)
+                            activity.SetTag("enduser.role", string.Join(",", roles.Select(r => r.Name)));
+                    }
+
+                    if (!string.IsNullOrEmpty(customer.Email))
+                        activity.SetTag("mysnacks.customer.email", customer.Email);
+                }
+
+                var storeContext = services.GetService<IStoreContext>();
+                var store = storeContext == null ? null : await storeContext.GetCurrentStoreAsync();
+                if (store != null)
+                    activity.SetTag("mysnacks.store.name", store.Name);
+            }
+            catch
+            {
+                // telemetry enrichment must never break the request
+            }
+        }
+
+        /// <summary>
+        /// After AuthenticationStartup (500) so the customer is resolved from the
+        /// auth cookie / JWT bearer before we read it.
+        /// </summary>
+        public int Order => 1000;
+    }
+}


### PR DESCRIPTION
Adds `TraceEnrichmentStartup` (`INopStartup`, Order 700 — after auth/authz, before MVC endpoints) that tags the ASP.NET Core server span created by the zero-code .NET auto-instrumentation with the current MySnacks customer/store, so SigNoz traces are filterable/correlatable by user:

| tag | value |
|---|---|
| `enduser.id` | nopCommerce CustomerId (== Mixpanel distinct_id) |
| `enduser.role` | comma-joined customer role names |
| `mysnacks.customer.registered` | registered vs guest |
| `mysnacks.customer.guid` | customer GUID |
| `mysnacks.customer.email` | only when present |
| `mysnacks.store.name` | current store |

- No OpenTelemetry SDK dependency — `Activity.Current` is the live server span; `Activity` is in the BCL.
- Enrichment wrapped in try/catch so it can never break a request.
- **Verified on dev** (`mysnacks-dev`): guest requests → `enduser.id`/`registered=false`/`role=Guests`; logged-in API requests → `registered=true`, roles, and email populate on the server span in SigNoz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)