### PR TITLE
Add OrderSource column to track order channel (Web/Mobile/Kerpak)

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Orders/Order.cs
+++ b/src/Libraries/Nop.Core/Domain/Orders/Order.cs
@@ -54,6 +54,11 @@ namespace Nop.Core.Domain.Orders
         public int OrderStatusId { get; set; }
 
         /// <summary>
+        /// Gets or sets the order source identifier (channel the order was placed through)
+        /// </summary>
+        public int OrderSourceId { get; set; }
+
+        /// <summary>
         /// Gets or sets the shipping status identifier
         /// </summary>
         public int ShippingStatusId { get; set; }
@@ -324,6 +329,15 @@ namespace Nop.Core.Domain.Orders
         {
             get => (OrderStatus)OrderStatusId;
             set => OrderStatusId = (int)value;
+        }
+
+        /// <summary>
+        /// Gets or sets the order source (channel the order was placed through)
+        /// </summary>
+        public OrderSource OrderSource
+        {
+            get => (OrderSource)OrderSourceId;
+            set => OrderSourceId = (int)value;
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Core/Domain/Orders/OrderSource.cs
+++ b/src/Libraries/Nop.Core/Domain/Orders/OrderSource.cs
@@ -1,0 +1,28 @@
+namespace Nop.Core.Domain.Orders
+{
+    /// <summary>
+    /// Represents the channel an order was placed through
+    /// </summary>
+    public enum OrderSource
+    {
+        /// <summary>
+        /// Unknown / not classified (default; historical rows before this field existed)
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Storefront web checkout
+        /// </summary>
+        Web = 10,
+
+        /// <summary>
+        /// Mobile app
+        /// </summary>
+        Mobile = 20,
+
+        /// <summary>
+        /// Kerpak external integration
+        /// </summary>
+        Kerpak = 30
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/OrderSourceMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/OrderSourceMigration.cs
@@ -1,0 +1,32 @@
+using FluentMigrator;
+using Nop.Core.Domain.Orders;
+using Nop.Data.Mapping;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    [NopMigration("2026-06-23 00:00:00:0000000", "4.60.0", UpdateMigrationType.Data)]
+    [SkipMigrationOnInstall]
+    public class OrderSourceMigration : Migration
+    {
+        public override void Up()
+        {
+            if (!Schema
+                    .Table(NameCompatibilityManager.GetTableName(typeof(Order)))
+                    .Column(nameof(Order.OrderSourceId))
+                    .Exists())
+            {
+                //add new column; existing rows stay OrderSource.Unknown (0)
+                Alter.Table(NameCompatibilityManager.GetTableName(typeof(Order)))
+                    .AddColumn(nameof(Order.OrderSourceId)).AsInt32().NotNullable()
+                    .WithDefaultValue((int)OrderSource.Unknown)
+                    .SetExistingRowsTo((int)OrderSource.Unknown);
+            }
+        }
+
+        public override void Down()
+        {
+            Alter.Table(NameCompatibilityManager.GetTableName(typeof(Order)))
+                .AlterColumn(nameof(Order.OrderSourceId));
+        }
+    }
+}

--- a/src/Libraries/Nop.Services/Orders/IOrderReportService.cs
+++ b/src/Libraries/Nop.Services/Orders/IOrderReportService.cs
@@ -71,7 +71,8 @@ namespace Nop.Services.Orders
             string billingEmail = null, 
             string billingLastName = "",
             string orderNotes = null,
-            int customerId = 0);
+            int customerId = 0,
+            List<int> srcIds = null);
 
         /// <summary>
         /// Get order average report
@@ -250,6 +251,7 @@ namespace Nop.Services.Orders
             int warehouseId = 0, int billingCountryId = 0, int orderId = 0, string paymentMethodSystemName = null,
             List<int> osIds = null, List<int> psIds = null, List<int> ssIds = null,
             DateTime? startTimeUtc = null, DateTime? endTimeUtc = null,
-            string billingPhone = null, string billingEmail = null, string billingLastName = "", string orderNotes = null);
+            string billingPhone = null, string billingEmail = null, string billingLastName = "", string orderNotes = null,
+            List<int> srcIds = null);
     }
 }

--- a/src/Libraries/Nop.Services/Orders/IOrderService.cs
+++ b/src/Libraries/Nop.Services/Orders/IOrderService.cs
@@ -115,7 +115,7 @@ namespace Nop.Services.Orders
             int pageSize = int.MaxValue, bool getOnlyTotalCount = false,
             bool sendRateNotification = false,
             bool sortByDeliveryDate = false, DateTime? schedulDate = null, DateTime? scheduleDateTime = null,
-            string companyName = null, int deliveryHour = 0);
+            string companyName = null, int deliveryHour = 0, List<int> srcIds = null);
 
         /// <summary>
         /// Inserts an order

--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -838,7 +838,8 @@ namespace Nop.Services.Orders
                 CreatedOnUtc = DateTime.UtcNow,
                 CustomOrderNumber = string.Empty,
                 ScheduleDate = processPaymentRequest.ScheduleDate,
-                ScheduleDateTime = processPaymentRequest.ScheduleDate
+                ScheduleDateTime = processPaymentRequest.ScheduleDate,
+                OrderSourceId = (int)processPaymentRequest.OrderSource
             };
 
             if (details.BillingAddress is null)

--- a/src/Libraries/Nop.Services/Orders/OrderReportService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderReportService.cs
@@ -270,8 +270,9 @@ namespace Nop.Services.Orders
             string billingPhone = null, 
             string billingEmail = null, 
             string billingLastName = "",
-            string orderNotes = null, 
-            int customerId = 0)
+            string orderNotes = null,
+            int customerId = 0,
+            List<int> srcIds = null)
         {
             var query = _orderRepository.Table;
 
@@ -332,6 +333,9 @@ namespace Nop.Services.Orders
 
             if (ssIds != null && ssIds.Any())
                 query = query.Where(o => ssIds.Contains(o.ShippingStatusId));
+
+            if (srcIds != null && srcIds.Any())
+                query = query.Where(o => srcIds.Contains(o.OrderSourceId));
 
             if (startTimeUtc.HasValue)
                 query = query.Where(o => startTimeUtc.Value <= o.CreatedOnUtc);
@@ -914,7 +918,8 @@ namespace Nop.Services.Orders
             int warehouseId = 0, int billingCountryId = 0, int orderId = 0, string paymentMethodSystemName = null,
             List<int> osIds = null, List<int> psIds = null, List<int> ssIds = null,
             DateTime? startTimeUtc = null, DateTime? endTimeUtc = null,
-            string billingPhone = null, string billingEmail = null, string billingLastName = "", string orderNotes = null)
+            string billingPhone = null, string billingEmail = null, string billingLastName = "", string orderNotes = null,
+            List<int> srcIds = null)
         {
             var dontSearchPhone = string.IsNullOrEmpty(billingPhone);
             var dontSearchEmail = string.IsNullOrEmpty(billingEmail);
@@ -929,6 +934,8 @@ namespace Nop.Services.Orders
                 orders = orders.Where(o => psIds.Contains(o.PaymentStatusId));
             if (ssIds != null && ssIds.Any())
                 orders = orders.Where(o => ssIds.Contains(o.ShippingStatusId));
+            if (srcIds != null && srcIds.Any())
+                orders = orders.Where(o => srcIds.Contains(o.OrderSourceId));
 
             var manageStockInventoryMethodId = (int)ManageInventoryMethod.ManageStock;
 

--- a/src/Libraries/Nop.Services/Orders/OrderService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderService.cs
@@ -357,7 +357,7 @@ namespace Nop.Services.Orders
             string orderNotes = null, int pageIndex = 0, int pageSize = int.MaxValue,
             bool getOnlyTotalCount = false, bool sendRateNotification = false,
             bool sortByDeliveryDate = false, DateTime? schedulDate = null, DateTime? scheduleDateTime = null,
-            string companyName = null, int deliveryHour = 0)
+            string companyName = null, int deliveryHour = 0, List<int> srcIds = null)
         {
             var query = _orderRepository.Table;
 
@@ -438,6 +438,9 @@ namespace Nop.Services.Orders
 
             if (ssIds != null && ssIds.Any())
                 query = query.Where(o => ssIds.Contains(o.ShippingStatusId));
+
+            if (srcIds != null && srcIds.Any())
+                query = query.Where(o => srcIds.Contains(o.OrderSourceId));
 
             if (!string.IsNullOrEmpty(orderNotes))
                 query = query.Where(o => _orderNoteRepository.Table.Any(oNote => oNote.OrderId == o.Id && oNote.Note.Contains(orderNotes)));

--- a/src/Libraries/Nop.Services/Payments/ProcessPaymentRequest.cs
+++ b/src/Libraries/Nop.Services/Payments/ProcessPaymentRequest.cs
@@ -43,7 +43,12 @@ namespace Nop.Services.Payments
         public decimal OrderTotal { get; set; }
 
         public DateTime ScheduleDate { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the source channel the order is placed through (web, mobile, Kerpak, ...)
+        /// </summary>
+        public OrderSource OrderSource { get; set; }
+
         public bool IgnoreNotPublishedWarning { get; set; }
 
         /// <summary>

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/OrderModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/OrderModelFactory.cs
@@ -907,6 +907,17 @@ namespace Nop.Web.Areas.Admin.Factories
                     searchModel.AvailableOrderStatuses.FirstOrDefault().Selected = true;
             }
 
+            //prepare available order sources (channels); empty selection means "all"
+            foreach (OrderSource source in Enum.GetValues(typeof(OrderSource)))
+            {
+                searchModel.AvailableOrderSources.Add(new SelectListItem
+                {
+                    Text = FormatOrderSource(source),
+                    Value = ((int)source).ToString(),
+                    Selected = searchModel.OrderSourceIds?.Contains((int)source) ?? false
+                });
+            }
+
             await _baseAdminModelFactory.PreparePaymentStatusesAsync(searchModel.AvailablePaymentStatuses);
             if (searchModel.AvailablePaymentStatuses.Any())
             {
@@ -968,6 +979,20 @@ namespace Nop.Web.Areas.Admin.Factories
         /// A task that represents the asynchronous operation
         /// The task result contains the order list model
         /// </returns>
+        /// <summary>
+        /// Format the order source channel for display (emoji + label)
+        /// </summary>
+        protected static string FormatOrderSource(OrderSource source)
+        {
+            return source switch
+            {
+                OrderSource.Web => "🌐 Web",
+                OrderSource.Mobile => "📱 Mobile",
+                OrderSource.Kerpak => "🧊 Kerpak",
+                _ => "❓ Unknown"
+            };
+        }
+
         public virtual async Task<OrderListModel> PrepareOrderListModelAsync(OrderSearchModel searchModel)
         {
             if (searchModel == null)
@@ -977,6 +1002,8 @@ namespace Nop.Web.Areas.Admin.Factories
             var orderStatusIds = (searchModel.OrderStatusIds?.Contains(0) ?? true) ? null : searchModel.OrderStatusIds.ToList();
             var paymentStatusIds = (searchModel.PaymentStatusIds?.Contains(0) ?? true) ? null : searchModel.PaymentStatusIds.ToList();
             var shippingStatusIds = (searchModel.ShippingStatusIds?.Contains(0) ?? true) ? null : searchModel.ShippingStatusIds.ToList();
+            //OrderSource.Unknown is 0, a real selectable value, so empty selection (not a 0 sentinel) means "all"
+            var orderSourceIds = (searchModel.OrderSourceIds?.Any() ?? false) ? searchModel.OrderSourceIds.ToList() : null;
             var isLoggedAsVendor = await _workContext.GetCurrentVendorAsync() != null;
             if (isLoggedAsVendor)
                 searchModel.VendorId = (await _workContext.GetCurrentVendorAsync()).Id;
@@ -1013,9 +1040,10 @@ namespace Nop.Web.Areas.Admin.Factories
                 pageIndex: searchModel.Page - 1, 
                 pageSize: searchModel.PageSize, 
                 sortByDeliveryDate: searchModel.SortByDeliveryDate,
-                companyName: searchModel.Company, 
+                companyName: searchModel.Company,
                 deliveryHour: searchModel.DeliveryHourId,
-                schedulDate: searchModel.DeliveryDate);
+                schedulDate: searchModel.DeliveryDate,
+                srcIds: orderSourceIds);
 
             //prepare list model
             var model = await new OrderListModel().PrepareToGridAsync(searchModel, orders, () =>
@@ -1050,6 +1078,7 @@ namespace Nop.Web.Areas.Admin.Factories
                     //fill in additional values (not existing in the entity)
                     orderModel.StoreName = (await _storeService.GetStoreByIdAsync(order.StoreId))?.Name ?? "Deleted";
                     orderModel.OrderStatus = await _localizationService.GetLocalizedEnumAsync(order.OrderStatus);
+                    orderModel.OrderSource = FormatOrderSource(order.OrderSource);
                     orderModel.PaymentStatus = await _localizationService.GetLocalizedEnumAsync(order.PaymentStatus);
                     orderModel.ShippingStatus = await _localizationService.GetLocalizedEnumAsync(order.ShippingStatus);
                     orderModel.OrderTotal = await _priceFormatter.FormatPriceAsync(order.OrderTotal, true, false);
@@ -1078,6 +1107,8 @@ namespace Nop.Web.Areas.Admin.Factories
             var orderStatusIds = (searchModel.OrderStatusIds?.Contains(0) ?? true) ? null : searchModel.OrderStatusIds.ToList();
             var paymentStatusIds = (searchModel.PaymentStatusIds?.Contains(0) ?? true) ? null : searchModel.PaymentStatusIds.ToList();
             var shippingStatusIds = (searchModel.ShippingStatusIds?.Contains(0) ?? true) ? null : searchModel.ShippingStatusIds.ToList();
+            //OrderSource.Unknown is 0, a real selectable value, so empty selection (not a 0 sentinel) means "all"
+            var orderSourceIds = (searchModel.OrderSourceIds?.Any() ?? false) ? searchModel.OrderSourceIds.ToList() : null;
             if (await _workContext.GetCurrentVendorAsync() != null)
                 searchModel.VendorId = (await _workContext.GetCurrentVendorAsync()).Id;
             var startDateValue = !searchModel.StartDate.HasValue ? null
@@ -1103,7 +1134,8 @@ namespace Nop.Web.Areas.Admin.Factories
                 //billingEmail: searchModel.BillingEmail,
                 //billingLastName: searchModel.BillingLastName,
                 //billingCountryId: searchModel.BillingCountryId,
-                orderNotes: searchModel.OrderNotes);
+                orderNotes: searchModel.OrderNotes,
+                srcIds: orderSourceIds);
 
             var profit = await _orderReportService.ProfitReportAsync(storeId: searchModel.StoreId,
                 vendorId: searchModel.VendorId,
@@ -1119,7 +1151,8 @@ namespace Nop.Web.Areas.Admin.Factories
                 //billingEmail: searchModel.BillingEmail,
                 //billingLastName: searchModel.BillingLastName,
                 //billingCountryId: searchModel.BillingCountryId,
-                orderNotes: searchModel.OrderNotes);
+                orderNotes: searchModel.OrderNotes,
+                srcIds: orderSourceIds);
 
             var primaryStoreCurrency = await _currencyService.GetCurrencyByIdAsync(_currencySettings.PrimaryStoreCurrencyId);
             var shippingSum = await _priceFormatter
@@ -1172,6 +1205,7 @@ namespace Nop.Web.Areas.Admin.Factories
                 model.Rating = order.Rating;
                 model.RatingText = order.RatingText;
                 model.OrderStatus = await _localizationService.GetLocalizedEnumAsync(order.OrderStatus);
+                model.OrderSource = FormatOrderSource(order.OrderSource);
                 model.StoreName = (await _storeService.GetStoreByIdAsync(order.StoreId))?.Name ?? "Deleted";
                 model.CustomerInfo = await _customerService.IsRegisteredAsync(customer) ? customer.Email : await _localizationService.GetResourceAsync("Admin.Customers.Guest");
                 model.CreatedOn = await _dateTimeHelper.ConvertToUserTimeAsync(order.CreatedOnUtc, DateTimeKind.Utc);
@@ -2060,6 +2094,17 @@ namespace Nop.Web.Areas.Admin.Factories
                         }
                     }
                     searchModel.ShippingStatusIds = shippingStatusIds;
+                }
+                if (jObject["OrderSourceIds"] != null)
+                {
+                    //0 (Unknown) is a real value for sources, so keep it
+                    List<int> orderSourceIds = new List<int>();
+                    var jArray = jObject["OrderSourceIds"];
+                    foreach (var item in jArray)
+                    {
+                        orderSourceIds.Add(int.Parse(item.ToString()));
+                    }
+                    searchModel.OrderSourceIds = orderSourceIds;
                 }
             }
             catch (Exception e)

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Orders/OrderModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Orders/OrderModel.cs
@@ -42,6 +42,9 @@ namespace Nop.Web.Areas.Admin.Models.Orders
         [NopResourceDisplayName("Admin.Orders.Fields.CustomOrderNumber")]
         public string CustomOrderNumber { get; set; }
         public string Company { get; set; }
+
+        //channel the order was placed through (emoji + label), e.g. "📱 Mobile"
+        public string OrderSource { get; set; }
         
         //store
         [NopResourceDisplayName("Admin.Orders.Fields.Store")]

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Orders/OrderSearchModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Orders/OrderSearchModel.cs
@@ -18,6 +18,7 @@ namespace Nop.Web.Areas.Admin.Models.Orders
         {
             AvailableDeliveryHours = new List<SelectListItem>();
             AvailableOrderStatuses = new List<SelectListItem>();
+            AvailableOrderSources = new List<SelectListItem>();
             AvailablePaymentStatuses = new List<SelectListItem>();
             AvailableShippingStatuses = new List<SelectListItem>();
             AvailableStores = new List<SelectListItem>();
@@ -26,6 +27,7 @@ namespace Nop.Web.Areas.Admin.Models.Orders
             AvailablePaymentMethods = new List<SelectListItem>();
             AvailableCountries = new List<SelectListItem>();
             OrderStatusIds = new List<int>();
+            OrderSourceIds = new List<int>();
             PaymentStatusIds = new List<int>();
             ShippingStatusIds = new List<int>();
         }
@@ -52,6 +54,9 @@ namespace Nop.Web.Areas.Admin.Models.Orders
 
         [NopResourceDisplayName("Admin.Orders.List.OrderStatus")]
         public IList<int> OrderStatusIds { get; set; }
+
+        [NopResourceDisplayName("Order source")]
+        public IList<int> OrderSourceIds { get; set; }
 
         [NopResourceDisplayName("Admin.Orders.List.PaymentStatus")]
         public IList<int> PaymentStatusIds { get; set; }
@@ -103,6 +108,8 @@ namespace Nop.Web.Areas.Admin.Models.Orders
         public bool IsLoggedInAsVendor { get; set; }
 
         public IList<SelectListItem> AvailableOrderStatuses { get; set; }
+
+        public IList<SelectListItem> AvailableOrderSources { get; set; }
 
         public IList<SelectListItem> AvailablePaymentStatuses { get; set; }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
@@ -195,6 +195,14 @@
                                                 <nop-select asp-for="ShippingStatusIds" asp-items="Model.AvailableShippingStatuses" asp-multiple="true" />
                                             </div>
                                         </div>
+                                        <div class="form-group row" @(Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>
+                                            <div class="col-md-4">
+                                                <nop-label asp-for="OrderSourceIds" />
+                                            </div>
+                                            <div class="col-md-8">
+                                                <nop-select asp-for="OrderSourceIds" asp-items="Model.AvailableOrderSources" asp-multiple="true" />
+                                            </div>
+                                        </div>
                                         <div class="form-group row">
                                             <div class="col-md-4">
                                                 <nop-label asp-for="DeliveryDate" />
@@ -350,6 +358,7 @@
                                                     new FilterParameter(nameof(Model.EndDate), typeof(DateTime?)),
                                                     new FilterParameter(nameof(Model.OrderStatusIds)),
                                                     new FilterParameter(nameof(Model.ShippingStatusIds)),
+                                                    new FilterParameter(nameof(Model.OrderSourceIds)),
                                                     new FilterParameter(nameof(Model.StoreId)),
                                                     new FilterParameter(nameof(Model.VendorId)),
                                                     //new FilterParameter(nameof(Model.WarehouseId)),
@@ -409,6 +418,12 @@
                                 {
                                     Title = "Company",
                                     Width = "80"
+                                });
+                                gridModel.ColumnCollection.Add(new ColumnProperty(nameof(OrderModel.OrderSource))
+                                {
+                                    Title = "Source",
+                                    Width = "80",
+                                    ClassName = NopColumnClassDefaults.CenterAll
                                 });
                                 gridModel.ColumnCollection.Add(new ColumnProperty(nameof(OrderModel.StoreName))
                                 {
@@ -504,6 +519,7 @@
                                     OrderStatusIds: $('#@Html.IdFor(model => model.OrderStatusIds)').val(),
                                     PaymentStatusIds: $('#@Html.IdFor(model => model.PaymentStatusIds)').val(),
                                     ShippingStatusIds: $('#@Html.IdFor(model => model.ShippingStatusIds)').val(),
+                                    OrderSourceIds: $('#@Html.IdFor(model => model.OrderSourceIds)').val(),
                                     StoreId: $('#@Html.IdFor(model => model.StoreId)').val(),
                                     VendorId: $('#@Html.IdFor(model => model.VendorId)').val(),
                                     WarehouseId: $('#@Html.IdFor(model => model.WarehouseId)').val(),
@@ -658,6 +674,7 @@
                 searchModel.GoDirectlyToCustomOrderNumber = $('#GoDirectlyToCustomOrderNumber').val();
                 searchModel.OrderStatusIds = $('#OrderStatusIds').val();
                 searchModel.ShippingStatusIds = $('#ShippingStatusIds').val();
+                searchModel.OrderSourceIds = $('#OrderSourceIds').val();
                 $('#export-excel-selected-form #excelSearchModel').val(JSON.stringify(searchModel));
                 $('#export-excel-selected-form').submit();
                 updateTable('#orders-grid');
@@ -702,6 +719,7 @@
                 searchModel.GoDirectlyToCustomOrderNumber = $('#GoDirectlyToCustomOrderNumber').val();
                 searchModel.OrderStatusIds = $('#OrderStatusIds').val();
                 searchModel.ShippingStatusIds = $('#ShippingStatusIds').val();
+                searchModel.OrderSourceIds = $('#OrderSourceIds').val();
                 $('#pdf-invoice-selected-form #pdfSearchModel').val(JSON.stringify(searchModel));
                 $('#pdf-invoice-selected-form').submit();
                 updateTable('#orders-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
@@ -106,6 +106,14 @@
             </div>
             <div class="form-group row">
                 <div class="col-md-3">
+                    <label class="col-form-label">Order source</label>
+                </div>
+                <div class="col-md-9">
+                    <div class="form-text-row">@Model.OrderSource</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-3">
                     <nop-label asp-for="CustomerId" />
                 </div>
                 <div class="col-md-9">

--- a/src/Presentation/Nop.Web/Controllers/Api/Integration/OrderController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Integration/OrderController.cs
@@ -233,6 +233,7 @@ namespace Nop.Web.Controllers.Integration
             processPaymentRequest.CustomerId = customer.Id;
             processPaymentRequest.ScheduleDate = DateTime.UtcNow;
             processPaymentRequest.IgnoreNotPublishedWarning = true;
+            processPaymentRequest.OrderSource = OrderSource.Kerpak;
 
             processPaymentRequest.PaymentMethodSystemName = "Payments.CheckMoneyOrder";
             var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -581,6 +581,7 @@ namespace Nop.Web.Controllers.Api.Order
             processPaymentRequest.StoreId = store.Id;
             processPaymentRequest.CustomerId = customer.Id;
             processPaymentRequest.ScheduleDate = scheduleDateUtc;
+            processPaymentRequest.OrderSource = OrderSource.Mobile;
 
             processPaymentRequest.PaymentMethodSystemName = "Payments.CheckMoneyOrder";
             var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);

--- a/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
@@ -1130,6 +1130,7 @@ namespace Nop.Web.Controllers
                 processPaymentRequest.CustomerId = (await _workContext.GetCurrentCustomerAsync()).Id;
                 processPaymentRequest.PaymentMethodSystemName = await _genericAttributeService.GetAttributeAsync<string>(await _workContext.GetCurrentCustomerAsync(),
                     NopCustomerDefaults.SelectedPaymentMethodAttribute, (await _storeContext.GetCurrentStoreAsync()).Id);
+                processPaymentRequest.OrderSource = OrderSource.Web;
                 HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", processPaymentRequest);
                 var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
                 if (placeOrderResult.Success)
@@ -1833,6 +1834,7 @@ namespace Nop.Web.Controllers
                 processPaymentRequest.CustomerId = (await _workContext.GetCurrentCustomerAsync()).Id;
                 processPaymentRequest.PaymentMethodSystemName = await _genericAttributeService.GetAttributeAsync<string>(await _workContext.GetCurrentCustomerAsync(),
                     NopCustomerDefaults.SelectedPaymentMethodAttribute, (await _storeContext.GetCurrentStoreAsync()).Id);
+                processPaymentRequest.OrderSource = OrderSource.Web;
                 HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", processPaymentRequest);
                 var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
                 if (placeOrderResult.Success)


### PR DESCRIPTION
## Summary

Persists the channel an order was placed through as a first-class int-backed enum on the `Order` table, mirroring the existing `OrderStatus`/`OrderStatusId` pattern. Motivated by needing to distinguish mobile-app orders **and** the external **Kerpak** integration from regular web checkout.

## Design

- `OrderSource` enum: `Unknown=0, Web=10, Mobile=20, Kerpak=30` (spaced values leave room for future channels).
- `Order.OrderSourceId` (int column) + `OrderSource` wrapper property.
- `ProcessPaymentRequest` carries the source into `OrderProcessingService.SaveOrderDetailsAsync`.
- Stamped at the **three order-entry chokepoints**, all of which converge on `PlaceOrderAsync`:
  - `CheckoutController` (both `Confirm` + one-page checkout) → `Web`
  - mobile `Api/Order/OrderApiController.OrderConfirmation` → `Mobile`
  - Kerpak `Api/Integration/OrderController.Order` → `Kerpak`

## Migration

FluentMigrator `OrderSourceMigration` (`[SkipMigrationOnInstall]`, runs last) adds `OrderSourceId INT NOT NULL DEFAULT 0`; existing rows backfilled to `Unknown` (no historical guessing — a heuristic backfill can follow separately).

## Admin

- Emoji-labelled source (🌐 Web / 📱 Mobile / 🧊 Kerpak / ❓ Unknown) on the orders **list grid** and **order detail** page.
- Multi-select **source filter** on the list page. `Unknown=0` is a real value, so empty selection means "all" (keeps Unknown filterable) instead of the usual 0-sentinel.
- Filter threaded through `SearchOrdersAsync` **and** the totals aggregator (`GetOrderAverageReportLineAsync` + `ProfitReportAsync`) so the footer totals stay consistent with the active filter.

## Testing

- Full solution builds clean (0 errors).
- Deployed to **dev.mysnacks.shop** (image `hotfix-order-source-f1cfa3-172`); migration applied cleanly on startup, app healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)