### PR TITLE
Fix external-auth first/last name not saved on mobile Google login

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/Api/Security/AccountApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Security/AccountApiController.cs
@@ -163,9 +163,14 @@ namespace Nop.Web.Controllers.Api.Security
                         IsApproved = false // Not approved by default, decided by Company plugin
                     };
 
-                    // Add custom claims for additional user info
-                    authParameters.Claims.Add(new ExternalAuthenticationClaim("given_name", deserializedGoogleToken.given_name));
-                    authParameters.Claims.Add(new ExternalAuthenticationClaim("family_name", deserializedGoogleToken.family_name));
+                    // Add custom claims for additional user info.
+                    // First/last name MUST use the fully-namespaced WS-Federation claim types,
+                    // because AuthenticationEventConsumer (ExtendedAuth plugin) only matches those
+                    // when persisting FirstName/LastName generic attributes. Sending raw "given_name"/
+                    // "family_name" silently fails to populate the name (avatar still worked because
+                    // AuthenticationDefaults.AvatarClaimType is the raw string "picture").
+                    authParameters.Claims.Add(new ExternalAuthenticationClaim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/given_name", deserializedGoogleToken.given_name));
+                    authParameters.Claims.Add(new ExternalAuthenticationClaim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", deserializedGoogleToken.family_name));
                     authParameters.Claims.Add(new ExternalAuthenticationClaim("picture", deserializedGoogleToken.picture));
 
                     try


### PR DESCRIPTION
## Problem

Mobile Google login populated **email and avatar** on the customer but **not first/last name**.

**Root cause:** `AccountApiController.Login()` added the name claims with raw short keys (`given_name`/`family_name`), but the consumer that persists them — `Nop.Plugin.ExternalAuth.ExtendedAuth` `AuthenticationEventConsumer` (handles `CustomerAutoRegisteredByExternalMethodEvent`) — only matches the fully-namespaced WS-Federation claim URIs (`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/given_name`, `.../surname`, …). The names never matched and were dropped. The **avatar worked only by coincidence**: its lookup uses `AuthenticationDefaults.AvatarClaimType`, which is the raw string `"picture"` — matching what the controller sent. Email is unaffected (it's a direct property).

Browser OAuth (`AuthenticationController.LoginCallback`) was never affected because it forwards the already-namespaced `ClaimsPrincipal` claims as-is.

## Fix

Send the name claims with the namespaced types the consumer matches (`.../given_name` and `.../surname`); keep `picture` raw for the avatar. Note `family_name` is **not** in the consumer's last-name list, so it must be sent as `surname`.

## Data backfill (already applied to prod)

Existing affected customers were backfilled from `ExternalAuthenticationRecord.ExternalDisplayIdentifier` (still holds the Google display name): prod-mysnacks 5, prod-fxpro 1, prod-manychat 1, deeporigin 0. Script: `sql_scripts/2026-06-23-backfill-external-auth-names.sql` (in the monorepo, not this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)