### PR TITLE
Guard external-auth Login against missing/unknown provider (fix NRE)

### DIFF
--- a/src/Plugins/Nop.Plugin.ExternalAuth.ExtendedAuth/Controllers/AuthenticationController.cs
+++ b/src/Plugins/Nop.Plugin.ExternalAuth.ExtendedAuth/Controllers/AuthenticationController.cs
@@ -279,9 +279,22 @@ namespace Nop.Plugin.ExternalAuth.ExtendedAuthentication.Controllers
             //configure login callback action
             var socialMediaList = new SocialMediaList();
 
+            //resolve the callback path for the requested provider. Guard against a missing or
+            //unknown "authentication" value: automated clients scrape the rendered login link and
+            //request the raw href where the "&" separating the query params is the literal HTML
+            //entity "&amp;", so the parameter arrives named "amp;authentication" and this argument
+            //binds to null. Without the guard authentication.ToLower() throws a NullReferenceException.
+            var callbackPath = socialMediaList.SocialMedias
+                .Where(x => string.Equals(x.Name, authentication, StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.CallBackPath.ToLower())
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(callbackPath))
+                return RedirectToRoute("Login", new { returnUrl });
+
             var authenticationProperties = new AuthenticationProperties
             {
-                RedirectUri = "/" + socialMediaList.SocialMedias.Where(x => x.Name.ToLower() == authentication.ToLower()).Select(x => x.CallBackPath.ToLower()).FirstOrDefault() + "?returnUrl=" + returnUrl  //Url.Action("LoginCallback", "Authentication", new { returnUrl = returnUrl })
+                RedirectUri = "/" + callbackPath + "?returnUrl=" + returnUrl  //Url.Action("LoginCallback", "Authentication", new { returnUrl = returnUrl })
             };
 
             authenticationProperties.SetString(AuthenticationDefaults.ErrorCallback, Url.RouteUrl("Login", new { returnUrl }));


### PR DESCRIPTION
## Problem

`/authentication/login` throws `NullReferenceException` (HTTP 500) for a steady trickle of requests (~10/day). Stack:

```
System.NullReferenceException
  at ...AuthenticationController.<>c__DisplayClass20_0.<Login>b__0(SocialMedia x)
```

## Root cause (evidenced via SigNoz traces)

The login page renders the external-auth links with `asp-route-*` tag helpers (`PublicInfo.cshtml`). The `&` separating the `returnurl` and `authentication` query params is HTML-attribute-encoded to the entity `&amp;` in the rendered `href` — this is **correct HTML**, and real browsers decode it back to `&` on click (these requests succeed → 302).

Automated clients (confirmed by spoofed/templated User-Agents on every failing hit — e.g. `rv:{version}.0`, fake `Safari/184.1` build tokens) scrape the raw `href` text **without** HTML-entity-decoding, keep the literal `&amp;`, and request the URL verbatim (with `;`→`%3B`):

```
/authentication/login?returnurl=%2F<product>&amp%3Bauthentication=Google
```

Server-side the query then contains params `returnurl` and `amp;authentication` — there is **no** `authentication` param, so the `authentication` action argument binds to `null` and `authentication.ToLower()` throws.

SigNoz `mysnacks` server spans over 26h: 225 × 302 (real browsers, clean `&`) vs 10 × 500 (bot UAs, `&amp%3B`). No real users affected; it's bot-triggered log noise.

## Fix

Resolve the provider callback path with a null-safe, case-insensitive match and redirect to the storefront `Login` route when `authentication` is missing or unknown, instead of dereferencing it. Valid provider requests (Google/Facebook/etc.) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)