### PR TITLE
Fix order-placement race allowing daily spend cap bypass

### DIFF
--- a/src/Libraries/Nop.Services/Orders/IOrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/IOrderProcessingService.cs
@@ -31,6 +31,18 @@ namespace Nop.Services.Orders
         Task<PlaceOrderResult> PlaceOrderAsync(ProcessPaymentRequest processPaymentRequest);
 
         /// <summary>
+        /// Validates that the customer hasn't placed an order within the minimum order
+        /// placement interval (prevents 2 orders being placed within an X second time frame)
+        /// </summary>
+        /// <param name="customerId">Customer identifier</param>
+        /// <param name="storeId">Store identifier</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains true if placing a new order is allowed; otherwise false
+        /// </returns>
+        Task<bool> IsMinimumOrderPlacementIntervalValidAsync(int customerId, int storeId);
+
+        /// <summary>
         /// Update order totals
         /// </summary>
         /// <param name="updateOrderParameters">Parameters for the updating order</param>

--- a/src/Libraries/Nop.Services/Orders/NopOrderDefaults.cs
+++ b/src/Libraries/Nop.Services/Orders/NopOrderDefaults.cs
@@ -58,5 +58,17 @@ namespace Nop.Services.Orders
         #endregion
 
         #endregion
+
+        #region Locking defaults
+
+        /// <summary>
+        /// Gets a key for the lock used to serialize order placement per customer
+        /// </summary>
+        /// <remarks>
+        /// {0} : customer ID
+        /// </remarks>
+        public static string OrderPlacementLockKey => "Nop.order.placement.lock.{0}";
+
+        #endregion
     }
 }

--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Nop.Core;
+using Nop.Core.Caching;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Common;
 using Nop.Core.Domain.Customers;
@@ -65,6 +66,7 @@ namespace Nop.Services.Orders
         private readonly IGiftCardService _giftCardService;
         private readonly ILanguageService _languageService;
         private readonly ILocalizationService _localizationService;
+        private readonly ILocker _locker;
         private readonly ILogger _logger;
         private readonly IOrderService _orderService;
         private readonly IOrderTotalCalculationService _orderTotalCalculationService;
@@ -116,6 +118,7 @@ namespace Nop.Services.Orders
             IGiftCardService giftCardService,
             ILanguageService languageService,
             ILocalizationService localizationService,
+            ILocker locker,
             ILogger logger,
             IOrderService orderService,
             IOrderTotalCalculationService orderTotalCalculationService,
@@ -163,6 +166,7 @@ namespace Nop.Services.Orders
             _giftCardService = giftCardService;
             _languageService = languageService;
             _localizationService = localizationService;
+            _locker = locker;
             _logger = logger;
             _orderService = orderService;
             _orderTotalCalculationService = orderTotalCalculationService;
@@ -1581,6 +1585,30 @@ namespace Nop.Services.Orders
         }
 
         /// <summary>
+        /// Validates that the customer hasn't placed an order within the minimum order
+        /// placement interval (prevents 2 orders being placed within an X second time frame)
+        /// </summary>
+        /// <param name="customerId">Customer identifier</param>
+        /// <param name="storeId">Store identifier</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains true if placing a new order is allowed; otherwise false
+        /// </returns>
+        public virtual async Task<bool> IsMinimumOrderPlacementIntervalValidAsync(int customerId, int storeId)
+        {
+            if (_orderSettings.MinimumOrderPlacementInterval == 0)
+                return true;
+
+            var lastOrder = (await _orderService.SearchOrdersAsync(storeId: storeId, customerId: customerId, pageSize: 1))
+                .FirstOrDefault();
+            if (lastOrder == null)
+                return true;
+
+            var interval = DateTime.UtcNow - lastOrder.CreatedOnUtc;
+            return interval.TotalSeconds > _orderSettings.MinimumOrderPlacementInterval;
+        }
+
+        /// <summary>
         /// Places an order
         /// </summary>
         /// <param name="processPaymentRequest">Process payment request</param>
@@ -1602,14 +1630,33 @@ namespace Nop.Services.Orders
                 //prepare order details
                 var details = await PreparePlaceOrderDetailsAsync(processPaymentRequest);
 
-                var processPaymentResult = await GetProcessPaymentResultAsync(processPaymentRequest, details);
+                //serialize per customer: a payment processor's "amount already spent today/this
+                //period" check and the resulting order insert must be atomic with respect to
+                //other concurrent PlaceOrderAsync calls for the same customer, otherwise
+                //simultaneous requests (e.g. duplicate taps/retries) can each read the allowance
+                //before any sibling order is inserted and all pass the same spending cap
+                Order order = null;
+                ProcessPaymentResult processPaymentResult = null;
+                var lockAcquired = _locker.PerformActionWithLock(
+                    string.Format(NopOrderDefaults.OrderPlacementLockKey, processPaymentRequest.CustomerId),
+                    TimeSpan.FromSeconds(30),
+                    () =>
+                    {
+                        processPaymentResult = GetProcessPaymentResultAsync(processPaymentRequest, details).GetAwaiter().GetResult();
 
-                if (processPaymentResult == null)
-                    throw new NopException("processPaymentResult is not available");
+                        if (processPaymentResult == null)
+                            throw new NopException("processPaymentResult is not available");
+
+                        order = processPaymentResult.Success
+                            ? SaveOrderDetailsAsync(processPaymentRequest, processPaymentResult, details).GetAwaiter().GetResult()
+                            : null;
+                    });
+
+                if (!lockAcquired)
+                    throw new NopException(await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval"));
 
                 if (processPaymentResult.Success)
                 {
-                    var order = await SaveOrderDetailsAsync(processPaymentRequest, processPaymentResult, details);
                     result.PlacedOrder = order;
                     
                     order.CompanyId = (await _companyService.GetCompanyByCustomerIdAsync(

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -537,7 +537,19 @@ namespace Nop.Web.Controllers.Api.Order
                         "If the issue still persist please notify MySnacks team."
                 });
             }
-            
+
+            var minIntervalValid = await _orderProcessingService.IsMinimumOrderPlacementIntervalValidAsync(customer.Id, store.Id);
+            if (!minIntervalValid)
+            {
+                await _logger.WarningAsync($"Order placed too soon after the previous one for customer {customer.Id}", customer: customer);
+                return Ok(new
+                {
+                    success = false,
+                    code = (int)OrderResultCode.None,
+                    message = await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval")
+                });
+            }
+
             // Replace checkout attributes
             if(orderConfirmationApiModel != null)
             {

--- a/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
@@ -126,25 +126,6 @@ namespace Nop.Web.Controllers
 
         #region Utilities
 
-        /// <returns>A task that represents the asynchronous operation</returns>
-        protected virtual async Task<bool> IsMinimumOrderPlacementIntervalValidAsync(Customer customer)
-        {
-            //prevent 2 orders being placed within an X seconds time frame
-            if (_orderSettings.MinimumOrderPlacementInterval == 0)
-                return true;
-
-            var lastOrder = (await _orderService.SearchOrdersAsync(
-                    storeId: (await _storeContext.GetCurrentStoreAsync()).Id,
-                    customerId: (await _workContext.GetCurrentCustomerAsync()).Id, 
-                    pageSize: 1))
-                .FirstOrDefault();
-            if (lastOrder == null)
-                return true;
-
-            var interval = DateTime.UtcNow - lastOrder.CreatedOnUtc;
-            return interval.TotalSeconds > _orderSettings.MinimumOrderPlacementInterval;
-        }
-
         /// <summary>
         /// Parses the value indicating whether the "pickup in store" is allowed
         /// </summary>
@@ -1112,7 +1093,8 @@ namespace Nop.Web.Controllers
             try
             {
                 //prevent 2 orders being placed within an X seconds time frame
-                if (!await IsMinimumOrderPlacementIntervalValidAsync(await _workContext.GetCurrentCustomerAsync()))
+                if (!await _orderProcessingService.IsMinimumOrderPlacementIntervalValidAsync(
+                        (await _workContext.GetCurrentCustomerAsync()).Id, (await _storeContext.GetCurrentStoreAsync()).Id))
                     throw new Exception(await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval"));
 
                 //place order
@@ -1814,7 +1796,8 @@ namespace Nop.Web.Controllers
                     throw new Exception("Anonymous checkout is not allowed");
 
                 //prevent 2 orders being placed within an X seconds time frame
-                if (!await IsMinimumOrderPlacementIntervalValidAsync(await _workContext.GetCurrentCustomerAsync()))
+                if (!await _orderProcessingService.IsMinimumOrderPlacementIntervalValidAsync(
+                        (await _workContext.GetCurrentCustomerAsync()).Id, (await _storeContext.GetCurrentStoreAsync()).Id))
                     throw new Exception(await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval"));
 
                 //place order


### PR DESCRIPTION
## Summary

Customer 1971028 placed 5 identical orders in the same second via the mobile app on 2026-07-07. Each concurrent request independently read the customer's "amount spent today" allowance before any sibling order had been inserted, so all 5 passed the ~4000 AMD/day company allowance check — 13,500 AMD total against a 4000 AMD cap. Two gaps compounded: a TOCTOU race in the daily-allowance check, and a missing throttle on the mobile checkout path.

- **Race fix**: `OrderProcessingService.PlaceOrderAsync` now serializes the payment/allowance check + order insert per customer using the existing `ILocker` (the same locking primitive `Task.cs` already uses for scheduled tasks — backed by `MemoryCacheManager`/`DistributedCacheManager` depending on config). Concurrent requests for the same customer can no longer both observe a stale "$0 spent" allowance; a request that can't acquire the lock fails fast instead of racing.
- **Mobile throttle**: extracted the web storefront's `IsMinimumOrderPlacementIntervalValidAsync` (the existing 30-second re-order guard, previously only wired into `CheckoutController`) into a shared `IOrderProcessingService` method, and wired it into the mobile `OrderApiController.OrderConfirmation` endpoint, which previously skipped it entirely.

With this fix, a repeat of this scenario results in: the first request succeeds, and the others are rejected (either by the 30-second interval check or by the now-atomic allowance check) instead of all 5 going through.

## Test plan
- [x] `dotnet build src/NopCommerce.sln` — 0 errors
- [ ] Manually verify on dev: rapid-fire duplicate mobile checkout requests for one customer now result in only one order succeeding
- [ ] Manually verify web storefront checkout still respects the 30s interval (regression check on the refactor)