### PR TITLE
AmeriaBank vPOS self-pay + Hangfire dynamic scheduled tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ WORKDIR /src/Plugins/Nop.Plugin.Notifications.Manager
 RUN dotnet build Nop.Plugin.Notifications.Manager.csproj -c Release
 WORKDIR /src/Plugins/Nop.Plugin.Payments.Idram
 RUN dotnet build Nop.Plugin.Payments.Idram.csproj -c Release
+WORKDIR /src/Plugins/Nop.Plugin.Payments.AmeriaVPos
+RUN dotnet build Nop.Plugin.Payments.AmeriaVPos.csproj -c Release
 WORKDIR /src/Plugins/Nop.Plugin.Company.Company
 RUN dotnet build Nop.Plugin.Company.Company.csproj -c Release
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -27,7 +27,7 @@ No hot-reload — a full rebuild is required after any code change.
 
 ## Architecture
 
-This is a **nopCommerce 4.4** fork customized for the **MySnacks** platform, running on **.NET 7** (SDK 7.0.306).
+This is a **nopCommerce 4.4** fork customized for the **MySnacks** platform, running on **.NET 9** (SDK pinned in `global.json`, currently `9.0.109`). Note: some ASP.NET Core NuGet packages are still pinned around `7.0.x` even though the target framework is `net9.0`.
 
 ### Layered Structure
 
@@ -58,6 +58,11 @@ Tests/
 - **Repository pattern**: `IRepository<T>` in `Nop.Data` for all data access.
 - **Database migrations**: FluentMigrator in `Nop.Data/Migrations/`.
 - **Authentication**: JWT Bearer tokens configured in `appsettings.json`. APIs use Swagger/OpenAPI.
+
+### Scheduled Tasks (two engines)
+
+- **Legacy timer engine** (`Nop.Services/Tasks`): `TaskManager` creates one `Timer` per `ScheduleTask`, each firing every `Seconds` and self-POSTing to `/scheduletask/runtask`. Fixed-interval only; interval changes need an app restart.
+- **Hangfire** (dynamic/cron): a `ScheduleTask` with a non-empty `CronExpression` is owned by Hangfire (registered as a recurring job by `HangfireStartup`) and is skipped by the legacy `TaskManager` so it never double-fires. Recurring jobs trigger the task via the same self-POST path, so behavior matches the legacy engine. Hangfire job storage lives in each tenant's own DB (provider chosen from `dataSettings.json`); the dashboard is at `/hangfire`, gated by the `ManageScheduleTasks` permission and linked from Admin → System. The per-customer order-reminder feature (`Customer.RemindMeTime`) is the first consumer. See `docs/plans/2026-07-22-dynamic-scheduled-tasks.md`.
 
 ### Plugin System
 

--- a/src/Libraries/Nop.Core/Domain/Customers/Customer.cs
+++ b/src/Libraries/Nop.Core/Domain/Customers/Customer.cs
@@ -138,5 +138,13 @@ namespace Nop.Core.Domain.Customers
         public bool RateReminderNotification { get; set; }
         public bool RemindMeNotification { get; set; }
         public bool OrderStatusNotification { get; set; }
+
+        /// <summary>
+        /// Gets or sets the customer's preferred order-reminder time, as minutes after local midnight
+        /// (0-1439, snapped to 15-minute slots) in the customer's own time zone. Null means "no explicit
+        /// preference" - the tenant default (CatalogSettings.StartingTimeOfRemindMeTask) is used instead.
+        /// See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+        /// </summary>
+        public int? RemindMeTime { get; set; }
     }
 }

--- a/src/Libraries/Nop.Core/Domain/Customers/NopCustomerDefaults.cs
+++ b/src/Libraries/Nop.Core/Domain/Customers/NopCustomerDefaults.cs
@@ -37,6 +37,11 @@
         /// </summary>
         public static string UnlimitedAccountRoleName => "UnlimitedAccount";
 
+        /// <summary>
+        /// Gets a system name of 'company benefit exemption' customer role
+        /// </summary>
+        public static string CompanyBenefitExemptionRoleName => "Allowance Excempt";
+
         #endregion
 
         #region System customers

--- a/src/Libraries/Nop.Core/Domain/Tasks/ScheduleTask.cs
+++ b/src/Libraries/Nop.Core/Domain/Tasks/ScheduleTask.cs
@@ -28,6 +28,14 @@ namespace Nop.Core.Domain.Tasks
         public bool Enabled { get; set; }
 
         /// <summary>
+        /// Gets or sets an optional CRON expression (e.g. "*/15 * * * *"). When set, the task is a dynamic
+        /// task owned by the Hangfire scheduler (registered as a recurring job) and is skipped by the legacy
+        /// interval-timer engine (TaskManager). When null/empty, the task runs on the legacy <see cref="Seconds"/>
+        /// interval. See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+        /// </summary>
+        public string CronExpression { get; set; }
+
+        /// <summary>
         /// Gets or sets the value indicating whether a task should be stopped on some error
         /// </summary>
         public bool StopOnError { get; set; }

--- a/src/Libraries/Nop.Data/Mapping/Builders/Tasks/ScheduleTaskBuilder.cs
+++ b/src/Libraries/Nop.Data/Mapping/Builders/Tasks/ScheduleTaskBuilder.cs
@@ -18,7 +18,8 @@ namespace Nop.Data.Mapping.Builders.Tasks
         {
             table
                 .WithColumn(nameof(ScheduleTask.Name)).AsString(int.MaxValue).NotNullable()
-                .WithColumn(nameof(ScheduleTask.Type)).AsString(int.MaxValue).NotNullable();
+                .WithColumn(nameof(ScheduleTask.Type)).AsString(int.MaxValue).NotNullable()
+                .WithColumn(nameof(ScheduleTask.CronExpression)).AsString(100).Nullable();
         }
 
         #endregion

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/AddHangfireMenuLocaleMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/AddHangfireMenuLocaleMigration.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentMigrator;
+using Nop.Core.Domain.Localization;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    /// <summary>
+    /// Seeds the locale string resources for the dynamic-scheduled-tasks feature: the "Hangfire" admin menu
+    /// item under System (Areas/Admin/sitemap.config) and the CRON-expression column on the Schedule Tasks
+    /// grid. Seeds English defaults plus Armenian translations (tenants run English + Armenian, UniqueSeoCode
+    /// "am"). Idempotent - only inserts the key for a language when it is not already present, so it is safe on
+    /// install AND upgrade.
+    /// </summary>
+    [NopMigration("2026-07-22 00:00:00:0000000", "4.60.0", UpdateMigrationType.Data)]
+    public class AddHangfireMenuLocaleMigration : Migration
+    {
+        private readonly INopDataProvider _dataProvider;
+
+        public AddHangfireMenuLocaleMigration(INopDataProvider dataProvider)
+        {
+            _dataProvider = dataProvider;
+        }
+
+        public override void Up()
+        {
+            // ResourceName -> (English, Armenian)
+            var resources = new Dictionary<string, (string En, string Hy)>
+            {
+                ["Admin.System.Hangfire"] =
+                    ("Background jobs (Hangfire)",
+                     "Ֆոնային առաջադրանքներ (Hangfire)"),
+                ["Admin.System.ScheduleTasks.CronExpression"] =
+                    ("CRON expression",
+                     "CRON արտահայտություն"),
+                ["Admin.System.ScheduleTasks.CronExpression.Hint"] =
+                    ("Optional. When set (e.g. \"*/15 * * * *\"), the task runs on this CRON schedule via Hangfire and ignores the interval. Leave empty to use the interval (seconds).",
+                     "Ընտրովի։ Երբ նշված է (օր․՝ \"*/15 * * * *\"), առաջադրանքը կատարվում է այս CRON ժամանակացույցով Hangfire-ի միջոցով՝ անտեսելով ինտերվալը։ Թողեք դատարկ՝ ինտերվալը (վայրկյաններ) օգտագործելու համար։"),
+                ["Admin.System.ScheduleTasks.CronExpression.Invalid"] =
+                    ("Invalid CRON expression: {0}",
+                     "Անվավեր CRON արտահայտություն՝ {0}")
+            };
+
+            var languages = _dataProvider.GetTable<Language>().ToList();
+            var existing = _dataProvider.GetTable<LocaleStringResource>();
+
+            foreach (var lang in languages)
+            {
+                var isArmenian =
+                    string.Equals(lang.UniqueSeoCode, "am", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(lang.UniqueSeoCode, "hy", StringComparison.OrdinalIgnoreCase) ||
+                    (lang.Name != null && lang.Name.IndexOf("Armenian", StringComparison.OrdinalIgnoreCase) >= 0);
+
+                foreach (var kv in resources)
+                {
+                    var present = existing.Any(r => r.LanguageId == lang.Id && r.ResourceName == kv.Key);
+                    if (present)
+                        continue;
+
+                    _dataProvider.InsertEntityAsync(new LocaleStringResource
+                    {
+                        LanguageId = lang.Id,
+                        ResourceName = kv.Key,
+                        ResourceValue = isArmenian ? kv.Value.Hy : kv.Value.En
+                    }).GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        public override void Down()
+        {
+            // No rollback for seeded locale resources.
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/CustomerRemindMeTimeMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/CustomerRemindMeTimeMigration.cs
@@ -1,0 +1,33 @@
+using FluentMigrator;
+using Nop.Core.Domain.Customers;
+using Nop.Data.Mapping;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    /// <summary>
+    /// Adds the nullable <see cref="Customer.RemindMeTime"/> column (per-customer order-reminder time, minutes
+    /// after local midnight) to existing installs. Fresh installs get the column from the entity schema, so it
+    /// is skipped on install. Idempotent. See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    [NopMigration("2026-07-22 00:00:02:0000000", "4.60.0", UpdateMigrationType.Data)]
+    [SkipMigrationOnInstall]
+    public class CustomerRemindMeTimeMigration : Migration
+    {
+        public override void Up()
+        {
+            if (!Schema
+                    .Table(NameCompatibilityManager.GetTableName(typeof(Customer)))
+                    .Column(nameof(Customer.RemindMeTime))
+                    .Exists())
+            {
+                Alter.Table(NameCompatibilityManager.GetTableName(typeof(Customer)))
+                    .AddColumn(nameof(Customer.RemindMeTime)).AsInt32().Nullable();
+            }
+        }
+
+        public override void Down()
+        {
+            // no rollback
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/MigrateScheduleTasksToCronMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/MigrateScheduleTasksToCronMigration.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentMigrator;
+using LinqToDB;
+using Nop.Core.Domain.Tasks;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    /// <summary>
+    /// Migrates existing fixed-interval schedule tasks onto the dynamic Hangfire scheduler by deriving a CRON
+    /// expression from each task's Seconds interval. Only tasks whose interval maps CLEANLY onto a standard CRON
+    /// (clock-aligned: whole minutes that divide 60, whole hours that divide 24, or daily) are converted; odd
+    /// intervals (e.g. 40 min) and sub-minute intervals are left on the legacy timer. Only rows that do not yet
+    /// have a CronExpression are touched, so the reminder task (already set to "*/15 * * * *") is untouched and
+    /// re-running is safe. Once a task has a CronExpression, TaskManager skips it and Hangfire owns it.
+    /// See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    [NopMigration("2026-07-23 00:00:00:0000000", "4.60.0", UpdateMigrationType.Data)]
+    [SkipMigrationOnInstall]
+    public class MigrateScheduleTasksToCronMigration : Migration
+    {
+        private readonly INopDataProvider _dataProvider;
+
+        public MigrateScheduleTasksToCronMigration(INopDataProvider dataProvider)
+        {
+            _dataProvider = dataProvider;
+        }
+
+        /// <summary>
+        /// Converts a fixed interval (seconds) into a clock-aligned standard 5-field CRON expression.
+        /// Returns null when the interval does not map cleanly (leave such tasks on the legacy timer).
+        /// Sub-minute intervals are intentionally not converted (Hangfire's scheduler polls ~every 15s, so
+        /// sub-minute CRON would not fire reliably).
+        /// </summary>
+        public static string SecondsToCron(int seconds)
+        {
+            if (seconds < 60)
+                return null;
+            if (seconds % 60 != 0)
+                return null;
+
+            var minutes = seconds / 60;
+
+            if (minutes == 1)
+                return "* * * * *";
+            if (minutes < 60)
+                return 60 % minutes == 0 ? $"*/{minutes} * * * *" : null;
+            if (minutes % 60 != 0)
+                return null;
+
+            var hours = minutes / 60;
+
+            if (hours == 1)
+                return "0 * * * *";
+            if (hours < 24)
+                return 24 % hours == 0 ? $"0 */{hours} * * *" : null;
+            if (hours % 24 != 0)
+                return null;
+
+            //whole number of days -> only a single-day cadence maps to a simple daily CRON
+            return hours / 24 == 1 ? "0 0 * * *" : null;
+        }
+
+        public override void Up()
+        {
+            var table = _dataProvider.GetTable<ScheduleTask>();
+
+            //only tasks not already owned by Hangfire (no CronExpression yet)
+            var tasks = table
+                .Where(t => t.CronExpression == null || t.CronExpression == string.Empty)
+                .ToList();
+
+            foreach (var task in tasks)
+            {
+                var cron = SecondsToCron(task.Seconds);
+                if (string.IsNullOrEmpty(cron))
+                    continue; //odd/sub-minute interval: leave on the legacy timer
+
+                table
+                    .Where(t => t.Id == task.Id)
+                    .Set(t => t.CronExpression, cron)
+                    .Update();
+            }
+        }
+
+        public override void Down()
+        {
+            // no rollback
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/RemindMeTaskCronMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/RemindMeTaskCronMigration.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using FluentMigrator;
+using LinqToDB;
+using Nop.Core.Domain.Tasks;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    /// <summary>
+    /// Switches the "Remind Me Notification Task" onto the dynamic Hangfire scheduler: it gets a 15-minute CRON
+    /// so the reminder dispatcher buckets customers by their chosen 15-minute slot. Seconds is lowered to 60 so
+    /// the legacy interval-gate in Task.ExecuteAsync always passes when Hangfire triggers the task via the
+    /// self-POST path (the task no longer runs on the legacy timer once a CRON is set - see TaskManager).
+    /// Idempotent (re-running just re-sets the same values). See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    [NopMigration("2026-07-22 00:00:03:0000000", "4.60.0", UpdateMigrationType.Data)]
+    [SkipMigrationOnInstall]
+    public class RemindMeTaskCronMigration : Migration
+    {
+        private readonly INopDataProvider _dataProvider;
+
+        public RemindMeTaskCronMigration(INopDataProvider dataProvider)
+        {
+            _dataProvider = dataProvider;
+        }
+
+        public override void Up()
+        {
+            const string taskType = "Nop.Plugin.Notifications.Manager.ScheduledTasks.RemindMeNotificationTask";
+
+            _dataProvider.GetTable<ScheduleTask>()
+                .Where(st => st.Type == taskType)
+                .Set(st => st.CronExpression, "*/15 * * * *")
+                .Set(st => st.Seconds, 60)
+                .Update();
+        }
+
+        public override void Down()
+        {
+            // no rollback
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/ScheduleTaskCronExpressionMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/CustomUpdateMigration/ScheduleTaskCronExpressionMigration.cs
@@ -1,0 +1,33 @@
+using FluentMigrator;
+using Nop.Core.Domain.Tasks;
+using Nop.Data.Mapping;
+
+namespace Nop.Data.Migrations.CustomUpdateMigration
+{
+    /// <summary>
+    /// Adds the nullable <see cref="ScheduleTask.CronExpression"/> column to existing installs. Fresh installs
+    /// get the column from <c>ScheduleTaskBuilder</c>, so this is skipped on install. Idempotent.
+    /// See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    [NopMigration("2026-07-22 00:00:01:0000000", "4.60.0", UpdateMigrationType.Data)]
+    [SkipMigrationOnInstall]
+    public class ScheduleTaskCronExpressionMigration : Migration
+    {
+        public override void Up()
+        {
+            if (!Schema
+                    .Table(NameCompatibilityManager.GetTableName(typeof(ScheduleTask)))
+                    .Column(nameof(ScheduleTask.CronExpression))
+                    .Exists())
+            {
+                Alter.Table(NameCompatibilityManager.GetTableName(typeof(ScheduleTask)))
+                    .AddColumn(nameof(ScheduleTask.CronExpression)).AsString(100).Nullable();
+            }
+        }
+
+        public override void Down()
+        {
+            // no rollback
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Nop.Data.csproj
+++ b/src/Libraries/Nop.Data/Nop.Data.csproj
@@ -18,6 +18,12 @@
     <PackageReference Include="MySql.Data" Version="8.0.23" />
     <PackageReference Include="Npgsql" Version="6.0.11" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <!-- Hangfire persistent job storage (provider chosen at runtime in HangfireStartup).
+         Hangfire.PostgreSql 1.19.x uses Npgsql >= 6.0.0 (keeps the pinned 6.0.11); do NOT bump to 1.20+,
+         which moves to Npgsql 8 and would break linq2db. Hangfire.SqlServer auto-detects the ADO client and
+         reuses the existing System.Data.SqlClient. -->
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.14" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.19.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -912,12 +912,18 @@ namespace Nop.Services.Orders
             if (orderPlacedCustomerNotificationQueuedEmailIds.Any())
                 await AddOrderNoteAsync(order, $"\"Order placed\" email (to customer) has been queued. Queued email identifiers: {string.Join(", ", orderPlacedCustomerNotificationQueuedEmailIds)}.");
 
-            var vendors = await GetVendorsInOrderAsync(order);
-            foreach (var vendor in vendors)
+            //vendors are notified once payment actually resolves (see OrderPaid.VendorNotification in
+            //ProcessOrderPaidAsync) so they don't get told to prep an order that may still be
+            //declined/abandoned by a redirect-based payment method (e.g. AmeriaVPos)
+            if (order.PaymentStatus != PaymentStatus.Pending)
             {
-                var orderPlacedVendorNotificationQueuedEmailIds = await _workflowMessageService.SendOrderPlacedVendorNotificationAsync(order, vendor, _localizationSettings.DefaultAdminLanguageId);
-                if (orderPlacedVendorNotificationQueuedEmailIds.Any())
-                    await AddOrderNoteAsync(order, $"\"Order placed\" email (to vendor) has been queued. Queued email identifiers: {string.Join(", ", orderPlacedVendorNotificationQueuedEmailIds)}.");
+                var vendors = await GetVendorsInOrderAsync(order);
+                foreach (var vendor in vendors)
+                {
+                    var orderPlacedVendorNotificationQueuedEmailIds = await _workflowMessageService.SendOrderPlacedVendorNotificationAsync(order, vendor, _localizationSettings.DefaultAdminLanguageId);
+                    if (orderPlacedVendorNotificationQueuedEmailIds.Any())
+                        await AddOrderNoteAsync(order, $"\"Order placed\" email (to vendor) has been queued. Queued email identifiers: {string.Join(", ", orderPlacedVendorNotificationQueuedEmailIds)}.");
+                }
             }
 
             if (order.AffiliateId == 0)

--- a/src/Libraries/Nop.Services/Payments/IAmeriaVPosPaymentService.cs
+++ b/src/Libraries/Nop.Services/Payments/IAmeriaVPosPaymentService.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using Nop.Core.Domain.Orders;
+
+namespace Nop.Services.Payments;
+
+/// <summary>
+/// Core AmeriaBank vPOS payment logic, shared between the web IPaymentMethod flow
+/// (Nop.Plugin.Payments.AmeriaVPos) and the mobile order-confirmation API
+/// (which needs the same allowance-vs-total decision but a JSON response instead
+/// of an HTTP redirect).
+/// </summary>
+public interface IAmeriaVPosPaymentService
+{
+    /// <summary>
+    /// Resolves whether <paramref name="order"/> is fully covered by the customer's
+    /// company allowance (marks it Paid directly, no card involved) or needs a card
+    /// payment for the shortfall (creates a payment attempt and returns a redirect URL).
+    /// </summary>
+    /// <param name="order">The just-placed order (Pending)</param>
+    /// <param name="platform">"Web" or "Mobile" - decides how BackUrlReturn redirects
+    /// once the attempt resolves (a mobile order has no OPC/cart session for the web
+    /// CheckoutCompleted page to render against, so it needs the mysnacks:// deep link
+    /// instead)</param>
+    Task<AmeriaVPosPaymentResult> InitiateOrCompletePaymentAsync(Order order, string platform = "Web");
+
+    /// <summary>
+    /// Pulls the authoritative status for the order's latest payment attempt from
+    /// AmeriaBank and updates the order/attempt accordingly. Used by the BackURL
+    /// return action and the abandoned-session reconciliation task - never trust a
+    /// redirect/deep-link query string instead of calling this.
+    /// </summary>
+    Task<AmeriaVPosPaymentResult> ResolvePaymentAsync(Order order);
+
+    /// <summary>
+    /// Reads the order's latest payment attempt status from the local ledger only - no
+    /// live AmeriaBank call. Used by the mobile deep-link return screen's status poll,
+    /// which should not hammer AmeriaBank on every check; BackURL return and the
+    /// reconciliation task are what keep the ledger itself up to date via ResolvePaymentAsync.
+    /// </summary>
+    Task<AmeriaVPosPaymentResult> GetLatestAttemptStatusAsync(Order order);
+
+    /// <summary>
+    /// Refunds (fully or partially) the order's completed payment attempt via AmeriaBank
+    /// and updates the order/attempt on success. Intentionally not exposed through the
+    /// standard IPaymentMethod.RefundAsync - callers must go through a distinct,
+    /// explicitly-confirmed admin action.
+    /// </summary>
+    Task<bool> RefundAsync(Order order, decimal amount);
+
+    /// <summary>
+    /// Cancels the order's completed payment attempt via AmeriaBank and updates the
+    /// order/attempt on success. Intentionally not exposed through the standard
+    /// IPaymentMethod.VoidAsync - see RefundAsync.
+    /// </summary>
+    Task<bool> CancelAsync(Order order);
+}
+
+public class AmeriaVPosPaymentResult
+{
+    /// <summary>
+    /// True if the order needs a card payment (fully or partially) and the customer
+    /// should be sent to <see cref="PaymentUrl"/>. False if it was fully covered by
+    /// allowance (already marked Paid) or has already resolved.
+    /// </summary>
+    public bool RequiresPayment { get; set; }
+
+    /// <summary>
+    /// The AmeriaBank hosted pay-page URL to redirect/open, when RequiresPayment is true
+    /// and no attempt has resolved yet.
+    /// </summary>
+    public string PaymentUrl { get; set; }
+
+    /// <summary>
+    /// The portion of the order total the customer must pay by card (the allowance
+    /// shortfall). Zero when the order is fully covered by allowance.
+    /// </summary>
+    public decimal AmountDue { get; set; }
+
+    /// <summary>
+    /// The portion of the order total covered by the customer's company allowance.
+    /// Zero for a fully allowance-exempt customer; equal to OrderTotal when fully covered.
+    /// </summary>
+    public decimal AmountCoveredByAllowance { get; set; }
+
+    /// <summary>
+    /// The resolved attempt status ("Paid", "Declined", "Refunded", "Cancelled",
+    /// "Redirected", "Abandoned") after ResolvePaymentAsync, or null before resolution.
+    /// </summary>
+    public string Status { get; set; }
+
+    /// <summary>
+    /// True once ResolvePaymentAsync has reached a terminal state (Paid/Declined) for
+    /// the latest attempt - false while still Redirected/unresolved.
+    /// </summary>
+    public bool Resolved { get; set; }
+
+    /// <summary>
+    /// "Web" or "Mobile" - which surface initiated the latest attempt. Used by
+    /// BackUrlReturn to pick the right redirect target once resolved.
+    /// </summary>
+    public string Platform { get; set; }
+}

--- a/src/Libraries/Nop.Services/Tasks/IRecurringTaskRegistrar.cs
+++ b/src/Libraries/Nop.Services/Tasks/IRecurringTaskRegistrar.cs
@@ -1,0 +1,16 @@
+namespace Nop.Services.Tasks
+{
+    /// <summary>
+    /// Registers dynamic (CRON) schedule tasks with an external recurring-job scheduler (e.g. Hangfire).
+    /// Implementations are invoked once during application startup, AFTER database migrations have been applied,
+    /// so they may safely read schedule-task columns added by migrations (e.g. CronExpression).
+    /// See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    public interface IRecurringTaskRegistrar
+    {
+        /// <summary>
+        /// Reconcile external recurring jobs against the current schedule-task configuration.
+        /// </summary>
+        System.Threading.Tasks.Task RegisterAsync();
+    }
+}

--- a/src/Libraries/Nop.Services/Tasks/TaskManager.cs
+++ b/src/Libraries/Nop.Services/Tasks/TaskManager.cs
@@ -40,6 +40,9 @@ namespace Nop.Services.Tasks
 
             var scheduleTasks = taskService
                 .GetAllTasksAsync().Result
+                //tasks carrying a CRON expression are owned by the Hangfire scheduler (registered as recurring
+                //jobs); exclude them here so they never fire on both engines. See HangfireStartup.
+                .Where(x => string.IsNullOrWhiteSpace(x.CronExpression))
                 .OrderBy(x => x.Seconds)
                 .ToList();
 

--- a/src/Plugins/Nop.Plugin.Company.Company/Controllers/CompanyBalanceApiController.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Controllers/CompanyBalanceApiController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
+using Nop.Plugin.Company.Company.Services;
 using Nop.Services.Payments;
 using Nop.Web.Controllers;
 using Nop.Web.Framework.Mvc.Filters;
@@ -20,7 +21,9 @@ namespace Nop.Plugin.Company.Company.Controllers
     [Authorize]
     public class CompanyBalanceApiController(
         ICompanyAllowancePaymentMethod companyAllowancePaymentMethod,
-        IWorkContext workContext)
+        IWorkContext workContext,
+        IStoreContext storeContext,
+        IDeliveryTimeStorageService deliveryTimeStorageService)
         : BaseApiController
     {
         /// <summary>
@@ -33,12 +36,24 @@ namespace Nop.Plugin.Company.Company.Controllers
         public async Task<IActionResult> GetBalanceAsync()
         {
             var customer = await workContext.GetCurrentCustomerAsync();
+            var store = await storeContext.GetCurrentStoreAsync();
+
+            // The allowance is a per-day cap, and the customer's already-selected
+            // delivery date (the same value the actual order placement checks
+            // against - see AmeriaVPosPaymentService/CheckMoneyOrderPaymentProcessor,
+            // both keyed on order.ScheduleDate) is what actually matters here, not
+            // "today". Falling back to DateTime.UtcNow was showing the checkout
+            // warning (and this same value on the profile balance card) based on
+            // today's usage even when the order is scheduled for a day with its own
+            // untouched allowance - e.g. today's cap fully used, but the order is
+            // scheduled for a future day with nothing booked against it yet.
+            var selectedDeliveryTime = await deliveryTimeStorageService.GetSelectedDeliveryTimeAsync(customer, store.Id);
 
             var balanceResult = await companyAllowancePaymentMethod.GetCustomerRemainingAllowance(
                 new CustomerBalanceRequest
                 {
                     Customer = customer,
-                    OrderDateUtc = DateTime.UtcNow
+                    OrderDateUtc = selectedDeliveryTime ?? DateTime.UtcNow
                 });
 
             if (balanceResult == null)

--- a/src/Plugins/Nop.Plugin.Company.Company/Services/DeliveryTimeService.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Services/DeliveryTimeService.cs
@@ -214,9 +214,15 @@ namespace Nop.Plugin.Company.Company.Services
         {
             var currentCustomer = await _workContext.GetCurrentCustomerAsync();
             var company = await _companyService.GetCompanyByCustomerIdAsync(currentCustomer.Id);
-            
-            // Use company's OrderAheadDays if available, otherwise use default
-            return company?.OrderAheadDays ?? ORDER_AHEAD_DAYS_DEFAULT;
+
+            // OrderAheadDays is a non-nullable int, so "company?.OrderAheadDays ?? DEFAULT"
+            // only ever fell back to DEFAULT when company itself was null - a company row
+            // whose OrderAheadDays is 0 (the type's default, and the only value reachable
+            // today since the admin UI to set it is unreachable - see _CreateOrUpdate.Info.cshtml)
+            // silently meant "0 days ahead" instead of "not configured". Treat <= 0 as unset.
+            return company != null && company.OrderAheadDays > 0
+                ? company.OrderAheadDays
+                : ORDER_AHEAD_DAYS_DEFAULT;
         }
 
         /// <summary>

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Info.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Info.cshtml
@@ -55,4 +55,14 @@
             <span asp-validation-for="AmountLimit"></span>
         </div>
     </div>
+
+    <div class="form-group row">
+        <div class="col-md-3">
+            <nop-label asp-for="OrderAheadDays" />
+        </div>
+        <div class="col-md-9">
+            <nop-editor asp-for="OrderAheadDays" />
+            <span asp-validation-for="OrderAheadDays"></span>
+        </div>
+    </div>
 </div>

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/RemindMeNotificationTask.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/RemindMeNotificationTask.cs
@@ -45,6 +45,13 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
         private readonly IOllamaApiClient _ollamaApiClient;
         private readonly ILogger _logger;
         private readonly PushNotificationService _pushNotificationService;
+        private readonly CatalogSettings _catalogSettings;
+
+        /// <summary>
+        /// Reminder-time slot granularity in minutes. The mobile picker offers 15-minute slots and this task
+        /// is registered as a Hangfire recurring job on the matching "*/15 * * * *" CRON.
+        /// </summary>
+        private const int SLOT_MINUTES = 15;
 
         private class CustomerNotificationMetadata
         {
@@ -52,15 +59,16 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
             public DateTime CurrentTime { get; set; }
             public ICollection<Product> PreviouslyOrderedProducts { get; set; }
         }
-        
+
         public RemindMeNotificationTask(IDateTimeHelper dateTimeHelper,
             ICustomerService customerService,
             IOrderService orderService,
             ICompanyService companyService,
-            IOllamaApiClient ollamaApiClient, 
-            ILogger logger, 
+            IOllamaApiClient ollamaApiClient,
+            ILogger logger,
             IProductService productService,
-            PushNotificationService pushNotificationService)
+            PushNotificationService pushNotificationService,
+            CatalogSettings catalogSettings)
         {
             _dateTimeHelper = dateTimeHelper;
             _customerService = customerService;
@@ -70,15 +78,39 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
             _logger = logger;
             _productService = productService;
             _pushNotificationService = pushNotificationService;
+            _catalogSettings = catalogSettings;
+        }
+
+        /// <summary>
+        /// Snaps a minute-of-day value into its 15-minute slot (0..1425), clamped to a valid day range.
+        /// </summary>
+        private static int SnapToSlot(int minutesOfDay)
+        {
+            if (minutesOfDay < 0)
+                minutesOfDay = 0;
+            if (minutesOfDay > 1439)
+                minutesOfDay = 1439;
+
+            return minutesOfDay / SLOT_MINUTES * SLOT_MINUTES;
+        }
+
+        /// <summary>
+        /// The tenant default reminder slot used when a customer has no explicit RemindMeTime.
+        /// Derived from CatalogSettings.StartingTimeOfRemindMeTask (interpreted as an hour), defaulting to 10:00.
+        /// </summary>
+        private int DefaultSlot()
+        {
+            var hour = _catalogSettings.StartingTimeOfRemindMeTask;
+            if (hour <= 0 || hour > 23)
+                hour = 10;
+
+            return SnapToSlot(hour * 60);
         }
 
         private async Task<ICollection<CustomerNotificationMetadata>> GetCustomersToNotify(int loadLastOrders = 40)
         {
             var customersToNotify = new List<CustomerNotificationMetadata>();
             
-            var companies = (await _companyService.GetAllCompaniesAsync())
-                .ToDictionary(c => c.Id);
-
             ICollection<Customer> customers =
                 await _customerService.GetAllPushNotificationCustomersAsync(isRemindMeNotification: true);
 
@@ -114,12 +146,29 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
                     continue;
                 }
                 
-                var timezoneInfo = !companies.TryGetValue(customer.Id, out var company) || company.TimeZone == null
+                // Prefer the customer's COMPANY time zone (resolved via the CompanyCustomer mapping), else fall
+                // back to the customer/store time zone. Previously this indexed a companies-by-Id dictionary
+                // with the CUSTOMER id, so it never matched and the company zone was silently ignored - every
+                // customer fell back to the store default zone.
+                var company = await _companyService.GetCompanyByCustomerIdAsync(customer.Id);
+                var timezoneInfo = string.IsNullOrEmpty(company?.TimeZone)
                     ? await _dateTimeHelper.GetCustomerTimeZoneAsync(customer)
                     : TZConvert.GetTimeZoneInfo(company.TimeZone);
 
                 var customerTime =
                     _dateTimeHelper.ConvertToUserTime(DateTime.UtcNow, TimeZoneInfo.Utc, timezoneInfo);
+
+                // Per-customer reminder-time gate: only notify when the current 15-minute slot (in the
+                // customer's time zone) matches the customer's chosen reminder time - or the tenant default
+                // when they have not set one. This buckets customers by their selected slot; the task runs
+                // every 15 minutes (Hangfire CRON) so each customer matches exactly once per day.
+                var currentSlot = SnapToSlot(customerTime.Hour * 60 + customerTime.Minute);
+                var desiredSlot = customer.RemindMeTime.HasValue
+                    ? SnapToSlot(customer.RemindMeTime.Value)
+                    : DefaultSlot();
+
+                if (currentSlot != desiredSlot)
+                    continue;
 
                 customersToNotify.Add(new CustomerNotificationMetadata()
                 {
@@ -228,9 +277,9 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
         /// </summary>
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            // var startingHour = await _settingService.GetSettingByKeyAsync("catalogSettings.StartingTimeOfRemindMeTask", 
-            //     10);
-
+            // Runs every 15 minutes (Hangfire CRON "*/15 * * * *"). GetCustomersToNotify() filters to the
+            // customers whose chosen 15-minute reminder slot matches the current time in their own time zone,
+            // so this run only processes the current slot's bucket rather than every opted-in customer.
             var expensiveProducts = await _productService.SearchProductsAsync(orderBy: ProductSortingEnum.PriceDesc);
             
             var productsToRecommend = expensiveProducts.Take(70)

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
@@ -132,6 +132,13 @@ namespace Nop.Plugin.Payments.AmeriaVPos
                 await _logger.ErrorAsync(
                     $"AmeriaVPos: order {postProcessPaymentRequest.Order.Id} requires payment but InitPayment " +
                     "did not return a redirect URL - see prior error log entry for the InitPayment failure.");
+
+                //without this, falling through here lets nopCommerce's stock OPC flow carry
+                //on to CheckoutCompleted - showing "successfully processed" for an order that
+                //was never charged. BackUrlReturn already renders PaymentFail.cshtml correctly
+                //for a resolved-but-not-Paid attempt, so just send the customer there.
+                _httpContextAccessor.HttpContext.Response.Redirect(
+                    $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?orderId={postProcessPaymentRequest.Order.Id}");
                 return;
             }
 

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
@@ -138,7 +138,7 @@ namespace Nop.Plugin.Payments.AmeriaVPos
                 //was never charged. BackUrlReturn already renders PaymentFail.cshtml correctly
                 //for a resolved-but-not-Paid attempt, so just send the customer there.
                 _httpContextAccessor.HttpContext.Response.Redirect(
-                    $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?orderId={postProcessPaymentRequest.Order.Id}");
+                    $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?msOrderId={postProcessPaymentRequest.Order.Id}");
                 return;
             }
 

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
@@ -42,7 +42,6 @@ namespace Nop.Plugin.Payments.AmeriaVPos
         private readonly IShoppingCartService _shoppingCartService;
         private readonly IOrderTotalCalculationService _orderTotalCalculationService;
         private readonly ICompanyAllowancePaymentMethod _companyAllowancePaymentMethod;
-        private readonly IPriceFormatter _priceFormatter;
         private readonly WidgetSettings _widgetSettings;
         private readonly ILogger _logger;
 
@@ -62,7 +61,6 @@ namespace Nop.Plugin.Payments.AmeriaVPos
             IShoppingCartService shoppingCartService,
             IOrderTotalCalculationService orderTotalCalculationService,
             ICompanyAllowancePaymentMethod companyAllowancePaymentMethod,
-            IPriceFormatter priceFormatter,
             WidgetSettings widgetSettings,
             ILogger logger)
         {
@@ -77,7 +75,6 @@ namespace Nop.Plugin.Payments.AmeriaVPos
             _shoppingCartService = shoppingCartService;
             _orderTotalCalculationService = orderTotalCalculationService;
             _companyAllowancePaymentMethod = companyAllowancePaymentMethod;
-            _priceFormatter = priceFormatter;
             _widgetSettings = widgetSettings;
             _logger = logger;
         }
@@ -193,20 +190,14 @@ namespace Nop.Plugin.Payments.AmeriaVPos
             var balance = await _companyAllowancePaymentMethod.GetCustomerRemainingAllowance(
                 new CustomerBalanceRequest { Customer = customer, OrderDateUtc = DateTime.UtcNow.Date });
 
+            //Never split a single order between allowance and card - see the comment on
+            //IAmeriaVPosPaymentService.InitiateOrCompletePaymentAsync for why (per-company
+            //invoice reconciliation attributes a whole order to one payer or the other).
             var remainingAllowance = balance?.RemainingAllowance ?? 0M;
-            var amountCoveredByAllowance = Math.Min(Math.Max(remainingAllowance, 0M), total);
-            var amountDue = total - amountCoveredByAllowance;
-
-            if (amountDue <= 0)
+            if (remainingAllowance >= total)
                 return string.Empty;
 
-            if (amountCoveredByAllowance <= 0)
-                return await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.FullSelfPay");
-
-            var covered = await _priceFormatter.FormatPriceAsync(amountCoveredByAllowance);
-            var due = await _priceFormatter.FormatPriceAsync(amountDue);
-            var format = await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.PartialSelfPay");
-            return string.Format(format, covered, due);
+            return await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.FullSelfPay");
         }
 
         public override string GetConfigurationPageUrl() =>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Nop.Core;
+using Nop.Core.Domain.Cms;
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Payments;
+using Nop.Plugin.Payments.AmeriaVPos.ScheduledTasks;
+using Nop.Services.Catalog;
+using Nop.Services.Cms;
+using Nop.Services.Configuration;
+using Nop.Services.Localization;
+using Nop.Services.Logging;
+using Nop.Services.Orders;
+using Nop.Services.Payments;
+using Nop.Services.Plugins;
+using Nop.Web.Framework.Infrastructure;
+using IScheduleTaskService = Nop.Services.Tasks.IScheduleTaskService;
+
+namespace Nop.Plugin.Payments.AmeriaVPos
+{
+    /// <summary>
+    /// AmeriaBank vPOS payment processor. Real decision logic (allowance-vs-total,
+    /// InitPayment) lives in the shared IAmeriaVPosPaymentService, not here directly,
+    /// because the mobile order-confirmation API needs the exact same logic but a JSON
+    /// response instead of an HTTP redirect - see IAmeriaVPosPaymentService.
+    /// </summary>
+    public class AmeriaVPosPaymentProcessor : BasePlugin, IPaymentMethod, IWidgetPlugin
+    {
+        #region Fields
+
+        private readonly IWebHelper _webHelper;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAmeriaVPosPaymentService _ameriaVPosPaymentService;
+        private readonly ISettingService _settingService;
+        private readonly ILocalizationService _localizationService;
+        private readonly IScheduleTaskService _scheduleTaskService;
+        private readonly IWorkContext _workContext;
+        private readonly IStoreContext _storeContext;
+        private readonly IShoppingCartService _shoppingCartService;
+        private readonly IOrderTotalCalculationService _orderTotalCalculationService;
+        private readonly ICompanyAllowancePaymentMethod _companyAllowancePaymentMethod;
+        private readonly IPriceFormatter _priceFormatter;
+        private readonly WidgetSettings _widgetSettings;
+        private readonly ILogger _logger;
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosPaymentProcessor(
+            IWebHelper webHelper,
+            IHttpContextAccessor httpContextAccessor,
+            IAmeriaVPosPaymentService ameriaVPosPaymentService,
+            ISettingService settingService,
+            ILocalizationService localizationService,
+            IScheduleTaskService scheduleTaskService,
+            IWorkContext workContext,
+            IStoreContext storeContext,
+            IShoppingCartService shoppingCartService,
+            IOrderTotalCalculationService orderTotalCalculationService,
+            ICompanyAllowancePaymentMethod companyAllowancePaymentMethod,
+            IPriceFormatter priceFormatter,
+            WidgetSettings widgetSettings,
+            ILogger logger)
+        {
+            _webHelper = webHelper;
+            _httpContextAccessor = httpContextAccessor;
+            _ameriaVPosPaymentService = ameriaVPosPaymentService;
+            _settingService = settingService;
+            _localizationService = localizationService;
+            _scheduleTaskService = scheduleTaskService;
+            _workContext = workContext;
+            _storeContext = storeContext;
+            _shoppingCartService = shoppingCartService;
+            _orderTotalCalculationService = orderTotalCalculationService;
+            _companyAllowancePaymentMethod = companyAllowancePaymentMethod;
+            _priceFormatter = priceFormatter;
+            _widgetSettings = widgetSettings;
+            _logger = logger;
+        }
+
+        #endregion
+
+        #region Properties
+
+        //real refunds/voids go through a separate, explicitly-confirmed admin action
+        //(AmeriaVPosController.RefundAmeriaPayment/CancelAmeriaPayment) - not these stock
+        //IPaymentMethod hooks, which the standard order-detail admin buttons call directly
+        public bool SupportCapture => false;
+        public bool SupportPartiallyRefund => false;
+        public bool SupportRefund => false;
+        public bool SupportVoid => false;
+
+        public RecurringPaymentType RecurringPaymentType => RecurringPaymentType.NotSupported;
+
+        public PaymentMethodType PaymentMethodType => PaymentMethodType.Redirection;
+
+        public bool SkipPaymentInfo => true;
+
+        /// <summary>
+        /// Hides this plugin's own "AmeriaVPos" entry on the admin Widgets list page -
+        /// it's a payment plugin that happens to also render an admin order-detail block,
+        /// not something a store owner would toggle from the widgets screen.
+        /// </summary>
+        public bool HideInWidgetList => true;
+
+        #endregion
+
+        #region Methods
+
+        public Task<ProcessPaymentResult> ProcessPaymentAsync(ProcessPaymentRequest processPaymentRequest)
+        {
+            //no-op - the order needs to exist (with an Id) before we can create a payment
+            //attempt row and call InitPayment, so the real logic runs in PostProcessPaymentAsync
+            return Task.FromResult(new ProcessPaymentResult());
+        }
+
+        public async Task PostProcessPaymentAsync(PostProcessPaymentRequest postProcessPaymentRequest)
+        {
+            var result = await _ameriaVPosPaymentService.InitiateOrCompletePaymentAsync(postProcessPaymentRequest.Order);
+
+            //fully covered by allowance - InitiateOrCompletePaymentAsync already marked the
+            //order Paid, nothing left to do; stock OPC flow continues on to CheckoutCompleted
+            if (!result.RequiresPayment)
+                return;
+
+            if (string.IsNullOrEmpty(result.PaymentUrl))
+            {
+                await _logger.ErrorAsync(
+                    $"AmeriaVPos: order {postProcessPaymentRequest.Order.Id} requires payment but InitPayment " +
+                    "did not return a redirect URL - see prior error log entry for the InitPayment failure.");
+                return;
+            }
+
+            _httpContextAccessor.HttpContext.Response.Redirect(result.PaymentUrl);
+        }
+
+        public Task<bool> CanRePostProcessPaymentAsync(Order order)
+        {
+            if (order == null)
+                throw new ArgumentNullException(nameof(order));
+
+            return Task.FromResult((DateTime.UtcNow - order.CreatedOnUtc).TotalSeconds >= 5.0);
+        }
+
+        public Task<CapturePaymentResult> CaptureAsync(CapturePaymentRequest capturePaymentRequest)
+        {
+            return Task.FromResult(new CapturePaymentResult { Errors = new[] { "Capture method not supported" } });
+        }
+
+        public async Task<decimal> GetAdditionalHandlingFeeAsync(IList<ShoppingCartItem> cart)
+        {
+            return await Task.FromResult(0M);
+        }
+
+        public Task<ProcessPaymentRequest> GetPaymentInfoAsync(IFormCollection form)
+        {
+            return Task.FromResult(new ProcessPaymentRequest());
+        }
+
+        /// <summary>
+        /// Rendered inline next to this method's radio button in the OPC payment-method
+        /// list (see CheckoutModelFactory.PreparePaymentMethodModel). This is the split
+        /// messaging the design calls for: no mention of a shortfall for a fully
+        /// allowance-exempt customer, but an explicit "balance covers X, pay Y by card"
+        /// note for a customer with a partial allowance who's over their limit for this
+        /// cart. Uses today's date as the schedule-date approximation for this preview -
+        /// the actual enforcement at order-placement time uses the real, validated
+        /// order.ScheduleDate (see IAmeriaVPosPaymentService.InitiateOrCompletePaymentAsync).
+        /// </summary>
+        public async Task<string> GetPaymentMethodDescriptionAsync()
+        {
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var store = await _storeContext.GetCurrentStoreAsync();
+            var cart = await _shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart, store.Id);
+            if (!cart.Any())
+                return string.Empty;
+
+            var cartTotals = await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart);
+            if (cartTotals.shoppingCartTotal is not decimal total || total <= 0)
+                return string.Empty;
+
+            var balance = await _companyAllowancePaymentMethod.GetCustomerRemainingAllowance(
+                new CustomerBalanceRequest { Customer = customer, OrderDateUtc = DateTime.UtcNow.Date });
+
+            var remainingAllowance = balance?.RemainingAllowance ?? 0M;
+            var amountCoveredByAllowance = Math.Min(Math.Max(remainingAllowance, 0M), total);
+            var amountDue = total - amountCoveredByAllowance;
+
+            if (amountDue <= 0)
+                return string.Empty;
+
+            if (amountCoveredByAllowance <= 0)
+                return await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.FullSelfPay");
+
+            var covered = await _priceFormatter.FormatPriceAsync(amountCoveredByAllowance);
+            var due = await _priceFormatter.FormatPriceAsync(amountDue);
+            var format = await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.PartialSelfPay");
+            return string.Format(format, covered, due);
+        }
+
+        public override string GetConfigurationPageUrl() =>
+            $"{_webHelper.GetStoreLocation()}Admin/AmeriaVPos/Configure";
+
+        public string GetPublicViewComponentName() => string.Empty;
+
+        public Task<bool> HidePaymentMethodAsync(IList<ShoppingCartItem> cart)
+        {
+            //always visible - unlike Idram, this method handles the fully-covered case
+            //internally (marks Paid, charges nothing), so there's no "would charge zero
+            //unnecessarily" case to hide for
+            return Task.FromResult(false);
+        }
+
+        public Task<ProcessPaymentResult> ProcessRecurringPaymentAsync(ProcessPaymentRequest processPaymentRequest)
+        {
+            return Task.FromResult(new ProcessPaymentResult { Errors = new[] { "Recurring payment not supported" } });
+        }
+
+        public Task<RefundPaymentResult> RefundAsync(RefundPaymentRequest refundPaymentRequest)
+        {
+            return Task.FromResult(new RefundPaymentResult { Errors = new[] { "Use the AmeriaBank refund admin action instead" } });
+        }
+
+        public Task<IList<string>> ValidatePaymentFormAsync(IFormCollection form) =>
+            Task.FromResult((IList<string>)new List<string>());
+
+        public Task<VoidPaymentResult> VoidAsync(VoidPaymentRequest voidPaymentRequest)
+        {
+            return Task.FromResult(new VoidPaymentResult { Errors = new[] { "Use the AmeriaBank cancel admin action instead" } });
+        }
+
+        public Task<CancelRecurringPaymentResult> CancelRecurringPaymentAsync(CancelRecurringPaymentRequest cancelPaymentRequest)
+        {
+            return Task.FromResult(new CancelRecurringPaymentResult { Errors = new[] { "Recurring payment not supported" } });
+        }
+
+        /// <summary>
+        /// Renders the separate, explicitly-confirmed Refund/Cancel buttons on the admin
+        /// Order Edit page via AmeriaVPosOrderActionsViewComponent - no core-view edits.
+        /// </summary>
+        public Task<IList<string>> GetWidgetZonesAsync()
+        {
+            return Task.FromResult<IList<string>>(new List<string> { AdminWidgetZones.OrderDetailsBlock });
+        }
+
+        public string GetWidgetViewComponentName(string widgetZone) => "AmeriaVPosOrderActions";
+
+        public override async Task InstallAsync()
+        {
+            await _settingService.SaveSettingAsync(new AmeriaVPosSettings
+            {
+                UseSandbox = true,
+                ApiBaseUrl = "https://servicestest.ameriabank.am/VPOS",
+                PayBaseUrl = "https://servicestest.ameriabank.am/VPOS"
+            });
+
+            await _localizationService.AddLocaleResourceAsync(new Dictionary<string, string>
+            {
+                ["Plugins.Payments.AmeriaVPos.Fields.ClientId"] = "Client ID",
+                ["Plugins.Payments.AmeriaVPos.Fields.ClientId.Hint"] = "Merchant ID issued by AmeriaBank.",
+                ["Plugins.Payments.AmeriaVPos.Fields.Username"] = "Username",
+                ["Plugins.Payments.AmeriaVPos.Fields.Username.Hint"] = "Merchant username issued by AmeriaBank.",
+                ["Plugins.Payments.AmeriaVPos.Fields.Password"] = "Password",
+                ["Plugins.Payments.AmeriaVPos.Fields.Password.Hint"] = "Merchant password issued by AmeriaBank.",
+                ["Plugins.Payments.AmeriaVPos.Fields.ApiBaseUrl"] = "API base URL",
+                ["Plugins.Payments.AmeriaVPos.Fields.ApiBaseUrl.Hint"] = "Base URL for the vPOS REST API. AmeriaBank has not issued a production hostname yet - only change this away from the sandbox value once they have.",
+                ["Plugins.Payments.AmeriaVPos.Fields.PayBaseUrl"] = "Pay page base URL",
+                ["Plugins.Payments.AmeriaVPos.Fields.PayBaseUrl.Hint"] = "Base URL for the hosted pay page customers are redirected to.",
+                ["Plugins.Payments.AmeriaVPos.Fields.UseSandbox"] = "Use sandbox",
+                ["Plugins.Payments.AmeriaVPos.Fields.UseSandbox.Hint"] = "Check to enable the AmeriaBank sandbox (testing) environment.",
+                ["Plugins.Payments.AmeriaVPos.PageTitle.Fail"] = "Payment Fail",
+                ["Plugins.Payments.AmeriaVPos.Checkout.Fail"] = "Failed Payment Process",
+                ["Plugins.Payments.AmeriaVPos.Checkout.YourPaymentHasBeenFailed"] =
+                    "Payment unsuccessful. Please contact administrator or try again.",
+                ["Plugins.Payments.AmeriaVPos.Checkout.Error.Continue"] = "Continue Checkout",
+                ["Plugins.Payments.AmeriaVPos.Description.FullSelfPay"] = "You'll be redirected to complete your payment by card.",
+                ["Plugins.Payments.AmeriaVPos.Description.PartialSelfPay"] = "Your balance covers {0} of this order - pay the remaining {1} by card to confirm.",
+                ["Plugins.Payments.AmeriaVPos.OrderActions.Title"] = "AmeriaBank vPOS",
+                ["Plugins.Payments.AmeriaVPos.OrderActions.ChargedAmount"] = "Amount charged via AmeriaBank: {0}",
+                ["Plugins.Payments.AmeriaVPos.OrderActions.RefundAmount"] = "Amount to refund:",
+                ["Plugins.Payments.AmeriaVPos.OrderActions.Refund"] = "Refund via AmeriaBank",
+                ["Plugins.Payments.AmeriaVPos.OrderActions.Cancel"] = "Cancel via AmeriaBank"
+            });
+
+            if (!_widgetSettings.ActiveWidgetSystemNames.Contains("Payments.AmeriaVPos"))
+            {
+                _widgetSettings.ActiveWidgetSystemNames.Add("Payments.AmeriaVPos");
+                await _settingService.SaveSettingAsync(_widgetSettings);
+            }
+
+            if (await _scheduleTaskService.GetTaskByTypeAsync(AmeriaVPosReconciliationTask.TASK_TYPE) == null)
+            {
+                await _scheduleTaskService.InsertTaskAsync(new Core.Domain.Tasks.ScheduleTask
+                {
+                    Enabled = true,
+                    Name = AmeriaVPosReconciliationTask.TASK_NAME,
+                    Type = AmeriaVPosReconciliationTask.TASK_TYPE,
+                    Seconds = 300
+                });
+            }
+
+            await base.InstallAsync();
+        }
+
+        public override async Task UninstallAsync()
+        {
+            var reconciliationTask = await _scheduleTaskService.GetTaskByTypeAsync(AmeriaVPosReconciliationTask.TASK_TYPE);
+            if (reconciliationTask != null)
+                await _scheduleTaskService.DeleteTaskAsync(reconciliationTask);
+
+            _widgetSettings.ActiveWidgetSystemNames.Remove("Payments.AmeriaVPos");
+            await _settingService.SaveSettingAsync(_widgetSettings);
+
+            await _settingService.DeleteSettingAsync<AmeriaVPosSettings>();
+            await _localizationService.DeleteLocaleResourcesAsync("Plugins.Payments.AmeriaVPos");
+            await base.UninstallAsync();
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosSettings.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosSettings.cs
@@ -1,0 +1,45 @@
+using Nop.Core.Configuration;
+
+namespace Nop.Plugin.Payments.AmeriaVPos
+{
+    public class AmeriaVPosSettings : ISettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the AmeriaBank sandbox environment
+        /// </summary>
+        public bool UseSandbox { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merchant Client ID issued by AmeriaBank
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merchant username issued by AmeriaBank
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merchant password issued by AmeriaBank
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base URL for the VPOS REST API (e.g. https://servicestest.ameriabank.am/VPOS
+        /// for sandbox). AmeriaBank has not yet issued a production hostname - this must be set to the
+        /// real one before UseSandbox is turned off.
+        /// </summary>
+        public string ApiBaseUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base URL for the hosted pay page the customer is redirected to
+        /// </summary>
+        public string PayBaseUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of minutes an initiated payment attempt is left
+        /// unresolved before the reconciliation task treats it as abandoned
+        /// </summary>
+        public int AbandonedAttemptTimeoutMinutes { get; set; } = 25;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Components/AmeriaVPosOrderActionsViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Components/AmeriaVPosOrderActionsViewComponent.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core.Domain.Orders;
+using Nop.Data;
+using Nop.Plugin.Payments.AmeriaVPos.Domain;
+using Nop.Plugin.Payments.AmeriaVPos.Models;
+using Nop.Services.Orders;
+using Nop.Services.Security;
+using Nop.Web.Framework.Components;
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Components
+{
+    /// <summary>
+    /// Renders the "Refund via AmeriaBank" / "Cancel via AmeriaBank" buttons on the admin
+    /// Order Edit page, via the AdminWidgetZones.OrderDetailsBlock widget zone - deliberately
+    /// NOT part of the stock _OrderDetails.Info.cshtml Refund/Void buttons (see design:
+    /// real card money needs a separate, explicitly-confirmed action). Only renders for
+    /// orders actually paid via AmeriaVPos with a completed charge to act on.
+    /// </summary>
+    [ViewComponent(Name = "AmeriaVPosOrderActions")]
+    public class AmeriaVPosOrderActionsViewComponent : NopViewComponent
+    {
+        private readonly IOrderService _orderService;
+        private readonly IPermissionService _permissionService;
+        private readonly IRepository<AmeriaVPosPaymentAttempt> _attemptRepository;
+
+        public AmeriaVPosOrderActionsViewComponent(
+            IOrderService orderService,
+            IPermissionService permissionService,
+            IRepository<AmeriaVPosPaymentAttempt> attemptRepository)
+        {
+            _orderService = orderService;
+            _permissionService = permissionService;
+            _attemptRepository = attemptRepository;
+        }
+
+        public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
+        {
+            if (additionalData is not BaseNopEntityModel entityModel)
+                return Content(string.Empty);
+
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageOrders))
+                return Content(string.Empty);
+
+            var order = await _orderService.GetOrderByIdAsync(entityModel.Id);
+            if (order == null || order.PaymentMethodSystemName != "Payments.AmeriaVPos")
+                return Content(string.Empty);
+
+            var attempt = await _attemptRepository.Table
+                .Where(a => a.OrderId == order.Id)
+                .OrderByDescending(a => a.Id)
+                .FirstOrDefaultAsync();
+
+            //nothing completed to refund/cancel - most orders on this method are either
+            //fully allowance-covered (no attempt at all) or still pending/declined
+            if (attempt?.Status != AmeriaVPosPaymentAttemptStatus.Paid)
+                return Content(string.Empty);
+
+            var model = new AmeriaVPosOrderActionsModel
+            {
+                OrderId = order.Id,
+                ChargedAmount = attempt.ChargedAmount ?? attempt.RequestedAmount
+            };
+
+            return View("~/Plugins/Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml", model);
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
@@ -137,13 +137,20 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Controllers
         /// session) gets bounced on into the app via the mysnacks:// deep link instead of
         /// nopCommerce's web CheckoutCompleted/PaymentFail pages, which have nothing to
         /// render against for a mobile order.
+        ///
+        /// The query param is named "msOrderId", NOT "orderId" - found live against the
+        /// sandbox 2026-07-22: AmeriaBank's own redirect appends its own querystring
+        /// (their OrderID, resposneCode, paymentID, opaque, description), and their OrderID
+        /// field is also literally named "orderId". Using the same key silently overwrote
+        /// ours with the AmeriaVPosPaymentAttempt row's own Id (their OrderID) instead of the
+        /// real nopCommerce Order.Id, sending every real bank round-trip to the wrong "order".
         /// </summary>
-        public async Task<IActionResult> BackUrlReturn(int orderId)
+        public async Task<IActionResult> BackUrlReturn(int msOrderId)
         {
-            var order = await _orderService.GetOrderByIdAsync(orderId);
+            var order = await _orderService.GetOrderByIdAsync(msOrderId);
             if (order == null)
             {
-                await _logger.WarningAsync($"AmeriaVPos BackUrlReturn: order {orderId} not found");
+                await _logger.WarningAsync($"AmeriaVPos BackUrlReturn: order {msOrderId} not found");
                 return View("~/Plugins/Payments.AmeriaVPos/Views/PaymentFail.cshtml");
             }
 

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
@@ -1,0 +1,218 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core;
+using Nop.Plugin.Payments.AmeriaVPos.Models;
+using Nop.Services.Configuration;
+using Nop.Services.Localization;
+using Nop.Services.Logging;
+using Nop.Services.Messages;
+using Nop.Services.Orders;
+using Nop.Services.Payments;
+using Nop.Services.Security;
+using Nop.Web.Framework;
+using Nop.Web.Framework.Controllers;
+using Nop.Web.Framework.Mvc.Filters;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Controllers
+{
+    public class AmeriaVPosController : BasePaymentController
+    {
+        #region Fields
+
+        private readonly IPermissionService _permissionService;
+        private readonly IStoreContext _storeContext;
+        private readonly ISettingService _settingService;
+        private readonly INotificationService _notificationService;
+        private readonly ILocalizationService _localizationService;
+        private readonly IOrderService _orderService;
+        private readonly IAmeriaVPosPaymentService _ameriaVPosPaymentService;
+        private readonly ILogger _logger;
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosController(
+            IPermissionService permissionService,
+            IStoreContext storeContext,
+            ISettingService settingService,
+            INotificationService notificationService,
+            ILocalizationService localizationService,
+            IOrderService orderService,
+            IAmeriaVPosPaymentService ameriaVPosPaymentService,
+            ILogger logger)
+        {
+            _permissionService = permissionService;
+            _storeContext = storeContext;
+            _settingService = settingService;
+            _notificationService = notificationService;
+            _localizationService = localizationService;
+            _orderService = orderService;
+            _ameriaVPosPaymentService = ameriaVPosPaymentService;
+            _logger = logger;
+        }
+
+        #endregion
+
+        #region Configuration
+
+        [AuthorizeAdmin]
+        [Area(AreaNames.Admin)]
+        public async Task<IActionResult> Configure()
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManagePaymentMethods))
+                return AccessDeniedView();
+
+            var storeScope = await _storeContext.GetActiveStoreScopeConfigurationAsync();
+            var settings = await _settingService.LoadSettingAsync<AmeriaVPosSettings>(storeScope);
+
+            var model = new ConfigurationModel
+            {
+                UseSandbox = settings.UseSandbox,
+                ClientId = settings.ClientId,
+                Username = settings.Username,
+                Password = settings.Password,
+                ApiBaseUrl = settings.ApiBaseUrl,
+                PayBaseUrl = settings.PayBaseUrl,
+                ActiveStoreScopeConfiguration = storeScope
+            };
+
+            if (storeScope <= 0)
+                return View("~/Plugins/Payments.AmeriaVPos/Views/Configure.cshtml", model);
+
+            model.UseSandbox_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.UseSandbox, storeScope);
+            model.ClientId_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.ClientId, storeScope);
+            model.Username_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.Username, storeScope);
+            model.Password_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.Password, storeScope);
+            model.ApiBaseUrl_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.ApiBaseUrl, storeScope);
+            model.PayBaseUrl_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.PayBaseUrl, storeScope);
+
+            return View("~/Plugins/Payments.AmeriaVPos/Views/Configure.cshtml", model);
+        }
+
+        [HttpPost]
+        [AuthorizeAdmin]
+        [Area(AreaNames.Admin)]
+        [AutoValidateAntiforgeryToken]
+        public async Task<IActionResult> Configure(ConfigurationModel model)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManagePaymentMethods))
+                return AccessDeniedView();
+
+            if (!ModelState.IsValid)
+                return await Configure();
+
+            var storeScope = await _storeContext.GetActiveStoreScopeConfigurationAsync();
+            var settings = await _settingService.LoadSettingAsync<AmeriaVPosSettings>(storeScope);
+
+            settings.UseSandbox = model.UseSandbox;
+            settings.ClientId = model.ClientId;
+            settings.Username = model.Username;
+            settings.Password = model.Password;
+            settings.ApiBaseUrl = model.ApiBaseUrl;
+            settings.PayBaseUrl = model.PayBaseUrl;
+
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.UseSandbox, model.UseSandbox_OverrideForStore, storeScope, false);
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.ClientId, model.ClientId_OverrideForStore, storeScope, false);
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.Username, model.Username_OverrideForStore, storeScope, false);
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.Password, model.Password_OverrideForStore, storeScope, false);
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.ApiBaseUrl, model.ApiBaseUrl_OverrideForStore, storeScope, false);
+            await _settingService.SaveSettingOverridablePerStoreAsync(settings, x => x.PayBaseUrl, model.PayBaseUrl_OverrideForStore, storeScope, false);
+
+            await _settingService.ClearCacheAsync();
+
+            _notificationService.SuccessNotification(await _localizationService.GetResourceAsync("Admin.Plugins.Saved"));
+
+            return await Configure();
+        }
+
+        #endregion
+
+        #region Payment return / admin actions
+
+        /// <summary>
+        /// AmeriaBank redirects the customer's browser here after payment. We never trust
+        /// the querystring - only the authoritative GetPaymentDetails pull inside
+        /// ResolvePaymentAsync. A mobile-originated attempt (system browser, no OPC/cart
+        /// session) gets bounced on into the app via the mysnacks:// deep link instead of
+        /// nopCommerce's web CheckoutCompleted/PaymentFail pages, which have nothing to
+        /// render against for a mobile order.
+        /// </summary>
+        public async Task<IActionResult> BackUrlReturn(int orderId)
+        {
+            var order = await _orderService.GetOrderByIdAsync(orderId);
+            if (order == null)
+            {
+                await _logger.WarningAsync($"AmeriaVPos BackUrlReturn: order {orderId} not found");
+                return View("~/Plugins/Payments.AmeriaVPos/Views/PaymentFail.cshtml");
+            }
+
+            var result = await _ameriaVPosPaymentService.ResolvePaymentAsync(order);
+
+            if (result.Platform == "Mobile")
+            {
+                return View("~/Plugins/Payments.AmeriaVPos/Views/MobileReturn.cshtml", order.Id);
+            }
+
+            if (result.Status == Domain.AmeriaVPosPaymentAttemptStatus.Paid.ToString())
+                return RedirectToRoute("CheckoutCompleted", new { orderId = order.Id });
+
+            return View("~/Plugins/Payments.AmeriaVPos/Views/PaymentFail.cshtml");
+        }
+
+        /// <summary>
+        /// Deliberately separate from the stock order-detail Refund button (which staff
+        /// use for benefit-funded orders with no real money involved) - this moves real
+        /// card money, so it gets its own explicitly-confirmed action.
+        /// </summary>
+        [HttpPost]
+        [AuthorizeAdmin]
+        [Area(AreaNames.Admin)]
+        [AutoValidateAntiforgeryToken]
+        public async Task<IActionResult> RefundAmeriaPayment(int orderId, decimal amount)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageOrders))
+                return AccessDeniedView();
+
+            var order = await _orderService.GetOrderByIdAsync(orderId);
+            if (order == null)
+                return RedirectToAction("List", "Order", new { area = AreaNames.Admin });
+
+            var success = await _ameriaVPosPaymentService.RefundAsync(order, amount);
+            if (success)
+                _notificationService.SuccessNotification("AmeriaBank refund completed.");
+            else
+                _notificationService.ErrorNotification("AmeriaBank refund failed - check the log for details.");
+
+            return RedirectToAction("Edit", "Order", new { id = orderId, area = AreaNames.Admin });
+        }
+
+        /// <summary>
+        /// Deliberately separate from the stock order-detail Cancel/Void button - see
+        /// RefundAmeriaPayment.
+        /// </summary>
+        [HttpPost]
+        [AuthorizeAdmin]
+        [Area(AreaNames.Admin)]
+        [AutoValidateAntiforgeryToken]
+        public async Task<IActionResult> CancelAmeriaPayment(int orderId)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageOrders))
+                return AccessDeniedView();
+
+            var order = await _orderService.GetOrderByIdAsync(orderId);
+            if (order == null)
+                return RedirectToAction("List", "Order", new { area = AreaNames.Admin });
+
+            var success = await _ameriaVPosPaymentService.CancelAsync(order);
+            if (success)
+                _notificationService.SuccessNotification("AmeriaBank payment cancelled.");
+            else
+                _notificationService.ErrorNotification("AmeriaBank cancel failed - check the log for details.");
+
+            return RedirectToAction("Edit", "Order", new { id = orderId, area = AreaNames.Admin });
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Controllers/AmeriaVPosController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
@@ -185,11 +186,19 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Controllers
             if (order == null)
                 return RedirectToAction("List", "Order", new { area = AreaNames.Admin });
 
-            var success = await _ameriaVPosPaymentService.RefundAsync(order, amount);
-            if (success)
-                _notificationService.SuccessNotification("AmeriaBank refund completed.");
-            else
-                _notificationService.ErrorNotification("AmeriaBank refund failed - check the log for details.");
+            try
+            {
+                var success = await _ameriaVPosPaymentService.RefundAsync(order, amount);
+                if (success)
+                    _notificationService.SuccessNotification("AmeriaBank refund completed.");
+                else
+                    _notificationService.ErrorNotification("AmeriaBank refund failed - check the log for details.");
+            }
+            catch (Exception exc)
+            {
+                await _logger.ErrorAsync($"AmeriaVPos RefundAmeriaPayment failed for order {orderId}", exc);
+                _notificationService.ErrorNotification(exc.Message);
+            }
 
             return RedirectToAction("Edit", "Order", new { id = orderId, area = AreaNames.Admin });
         }
@@ -211,11 +220,19 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Controllers
             if (order == null)
                 return RedirectToAction("List", "Order", new { area = AreaNames.Admin });
 
-            var success = await _ameriaVPosPaymentService.CancelAsync(order);
-            if (success)
-                _notificationService.SuccessNotification("AmeriaBank payment cancelled.");
-            else
-                _notificationService.ErrorNotification("AmeriaBank cancel failed - check the log for details.");
+            try
+            {
+                var success = await _ameriaVPosPaymentService.CancelAsync(order);
+                if (success)
+                    _notificationService.SuccessNotification("AmeriaBank payment cancelled.");
+                else
+                    _notificationService.ErrorNotification("AmeriaBank cancel failed - check the log for details.");
+            }
+            catch (Exception exc)
+            {
+                await _logger.ErrorAsync($"AmeriaVPos CancelAmeriaPayment failed for order {orderId}", exc);
+                _notificationService.ErrorNotification(exc.Message);
+            }
 
             return RedirectToAction("Edit", "Order", new { id = orderId, area = AreaNames.Admin });
         }

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Domain/AmeriaVPosPaymentAttempt.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Domain/AmeriaVPosPaymentAttempt.cs
@@ -1,0 +1,106 @@
+using System;
+using Nop.Core;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Domain
+{
+    /// <summary>
+    /// Status of an AmeriaVPos payment attempt
+    /// </summary>
+    public enum AmeriaVPosPaymentAttemptStatus
+    {
+        /// <summary>
+        /// InitPayment has not been called yet (row just created to reserve a VposOrderId)
+        /// </summary>
+        Started = 0,
+
+        /// <summary>
+        /// InitPayment succeeded; customer has been sent to the hosted pay page
+        /// </summary>
+        Redirected = 10,
+
+        /// <summary>
+        /// Confirmed paid via GetPaymentDetails
+        /// </summary>
+        Paid = 20,
+
+        /// <summary>
+        /// Confirmed declined via GetPaymentDetails
+        /// </summary>
+        Declined = 30,
+
+        /// <summary>
+        /// Refunded (fully or partially) via the admin refund action
+        /// </summary>
+        Refunded = 40,
+
+        /// <summary>
+        /// Cancelled/voided via the admin cancel action
+        /// </summary>
+        Cancelled = 50,
+
+        /// <summary>
+        /// Never resolved within the reconciliation window - treated as abandoned
+        /// </summary>
+        Abandoned = 60
+    }
+
+    /// <summary>
+    /// Represents one AmeriaBank vPOS InitPayment attempt for an order. A single order
+    /// may have multiple attempts (retries after a decline/abandonment), each with its
+    /// own AmeriaBank-facing OrderID (this row's own Id, decoupled from Order.Id -
+    /// AmeriaBank rejects a repeat InitPayment against the same OrderID).
+    /// </summary>
+    public partial class AmeriaVPosPaymentAttempt : BaseEntity
+    {
+        /// <summary>
+        /// Gets or sets the nopCommerce order identifier this attempt belongs to
+        /// </summary>
+        public int OrderId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 1-based attempt number for this order (1 = first attempt)
+        /// </summary>
+        public int AttemptNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AmeriaBank-facing PaymentID returned by InitPayment
+        /// </summary>
+        public string PaymentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount requested from AmeriaBank for this attempt (the
+        /// allowance shortfall, which may be less than the order total)
+        /// </summary>
+        public decimal RequestedAmount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount AmeriaBank confirmed as actually charged, once resolved
+        /// </summary>
+        public decimal? ChargedAmount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AmeriaBank RRN (transaction reference) once resolved
+        /// </summary>
+        public string Rrn { get; set; }
+
+        /// <summary>
+        /// Gets or sets which surface initiated this attempt ("Web" or "Mobile") - decides
+        /// how AmeriaVPosController.BackUrlReturn redirects once resolved (nopCommerce's
+        /// CheckoutCompleted page for web, the mysnacks:// deep link for mobile, since a
+        /// mobile order has no OPC/cart session for CheckoutCompleted to render against).
+        /// </summary>
+        public string Platform { get; set; }
+
+        public int StatusId { get; set; }
+
+        public AmeriaVPosPaymentAttemptStatus Status
+        {
+            get => (AmeriaVPosPaymentAttemptStatus)StatusId;
+            set => StatusId = (int)value;
+        }
+
+        public DateTime CreatedOnUtc { get; set; }
+
+        public DateTime? ResolvedOnUtc { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Infrastructure/DependencyRegistrar.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Infrastructure/DependencyRegistrar.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Configuration;
+using Nop.Core.Infrastructure;
+using Nop.Core.Infrastructure.DependencyManagement;
+using Nop.Plugin.Payments.AmeriaVPos.Services;
+using Nop.Services.Payments;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Infrastructure
+{
+    /// <summary>
+    /// Dependency registrar
+    /// </summary>
+    public class DependencyRegistrar : IDependencyRegistrar
+    {
+        public int Order => 1105;
+
+        public void Register(IServiceCollection services, ITypeFinder typeFinder, AppSettings appSettings)
+        {
+            services.AddScoped<IAmeriaVPosPaymentService, AmeriaVPosPaymentService>();
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Infrastructure/NopStartup.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Payments.AmeriaVPos.Services;
+using Nop.Web.Framework.Infrastructure.Extensions;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Infrastructure
+{
+    /// <summary>
+    /// Represents object for the configuring services on application startup
+    /// </summary>
+    public class NopStartup : INopStartup
+    {
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            //client to request AmeriaBank vPOS services
+            services.AddHttpClient<AmeriaVPosApiClient>().WithProxy();
+        }
+
+        public void Configure(IApplicationBuilder application)
+        {
+        }
+
+        public int Order => 102;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Migrations/AmeriaVPosPaymentAttemptMigration.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Migrations/AmeriaVPosPaymentAttemptMigration.cs
@@ -1,0 +1,45 @@
+using FluentMigrator;
+using Nop.Data.Mapping;
+using Nop.Data.Extensions;
+using Nop.Data.Migrations;
+using Nop.Plugin.Payments.AmeriaVPos.Domain;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Migrations
+{
+    [NopMigration("2026/07/21 00:00:00:0000000", "AmeriaVPos Payment Attempt")]
+    public class AmeriaVPosPaymentAttemptMigration : MigrationBase
+    {
+        #region Fields
+
+        private readonly IMigrationManager _migrationManager;
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosPaymentAttemptMigration(IMigrationManager migrationManager)
+        {
+            _migrationManager = migrationManager;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Collect the UP migration expressions
+        /// </summary>
+        public override void Up()
+        {
+            if (!Schema.Table(NameCompatibilityManager.GetTableName(typeof(AmeriaVPosPaymentAttempt))).Exists())
+                _migrationManager.BuildTable<AmeriaVPosPaymentAttempt>(Create);
+        }
+
+        public override void Down()
+        {
+            //add the downgrade logic if necessary
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Models/AmeriaVPosOrderActionsModel.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Models/AmeriaVPosOrderActionsModel.cs
@@ -1,0 +1,11 @@
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Models
+{
+    public record AmeriaVPosOrderActionsModel : BaseNopModel
+    {
+        public int OrderId { get; set; }
+
+        public decimal ChargedAmount { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Models/ConfigurationModel.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Models/ConfigurationModel.cs
@@ -1,0 +1,34 @@
+using Nop.Web.Framework.Mvc.ModelBinding;
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Models
+{
+    public record ConfigurationModel : BaseNopModel
+    {
+        public int ActiveStoreScopeConfiguration { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.UseSandbox")]
+        public bool UseSandbox { get; set; }
+        public bool UseSandbox_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.ClientId")]
+        public string ClientId { get; set; }
+        public bool ClientId_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.Username")]
+        public string Username { get; set; }
+        public bool Username_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.Password")]
+        public string Password { get; set; }
+        public bool Password_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.ApiBaseUrl")]
+        public string ApiBaseUrl { get; set; }
+        public bool ApiBaseUrl_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Plugins.Payments.AmeriaVPos.Fields.PayBaseUrl")]
+        public string PayBaseUrl { get; set; }
+        public bool PayBaseUrl_OverrideForStore { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Nop.Plugin.Payments.AmeriaVPos.csproj
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Nop.Plugin.Payments.AmeriaVPos.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Platform>AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <Version>1.0.0.0</Version>
+    <OutputPath>..\..\Presentation\Nop.Web\Plugins\Payments.AmeriaVPos</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web\Nop.Web.csproj" />
+    <ClearPluginAssemblies Include="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Views\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="plugin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\_ViewImports.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\Configure.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\PaymentFail.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\MobileReturn.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\OrderActions\OrderActions.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <!-- This target execute after "Build" target -->
+  <Target Name="NopTarget" AfterTargets="Build">
+    <!-- Delete unnecessary libraries from plugins path -->
+    <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(MSBuildProjectDirectory)\$(OutDir)" Targets="NopClear" />
+  </Target>
+</Project>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/ScheduledTasks/AmeriaVPosReconciliationTask.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/ScheduledTasks/AmeriaVPosReconciliationTask.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nop.Data;
+using Nop.Plugin.Payments.AmeriaVPos.Domain;
+using Nop.Services.Logging;
+using Nop.Services.Orders;
+using Nop.Services.Payments;
+using IScheduleTask = Nop.Services.Tasks.IScheduleTask;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.ScheduledTasks
+{
+    /// <summary>
+    /// Resolves AmeriaVPos payment attempts the customer never returned to BackURL for
+    /// (browser closed, app killed, network dropped). Pulls the authoritative status one
+    /// more time in case payment actually succeeded and we just missed the redirect, then
+    /// gives up and restores the cart if AmeriaBank also has no resolution after the
+    /// configured timeout - mirroring the abandoned-order handling Idram's Fail() action
+    /// already does for the web redirect-failure case.
+    /// </summary>
+    public class AmeriaVPosReconciliationTask : IScheduleTask
+    {
+        public const string TASK_TYPE = "Nop.Plugin.Payments.AmeriaVPos.ScheduledTasks.AmeriaVPosReconciliationTask";
+        public const string TASK_NAME = "AmeriaVPos abandoned payment reconciliation";
+
+        #region Fields
+
+        private readonly IRepository<AmeriaVPosPaymentAttempt> _attemptRepository;
+        private readonly IOrderService _orderService;
+        private readonly IOrderProcessingService _orderProcessingService;
+        private readonly IAmeriaVPosPaymentService _ameriaVPosPaymentService;
+        private readonly AmeriaVPosSettings _ameriaVPosSettings;
+        private readonly ILogger _logger;
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosReconciliationTask(
+            IRepository<AmeriaVPosPaymentAttempt> attemptRepository,
+            IOrderService orderService,
+            IOrderProcessingService orderProcessingService,
+            IAmeriaVPosPaymentService ameriaVPosPaymentService,
+            AmeriaVPosSettings ameriaVPosSettings,
+            ILogger logger)
+        {
+            _attemptRepository = attemptRepository;
+            _orderService = orderService;
+            _orderProcessingService = orderProcessingService;
+            _ameriaVPosPaymentService = ameriaVPosPaymentService;
+            _ameriaVPosSettings = ameriaVPosSettings;
+            _logger = logger;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public async Task ExecuteAsync()
+        {
+            var cutoff = DateTime.UtcNow.AddMinutes(-_ameriaVPosSettings.AbandonedAttemptTimeoutMinutes);
+
+            var staleAttempts = await _attemptRepository.Table
+                .Where(a => a.StatusId == (int)AmeriaVPosPaymentAttemptStatus.Redirected && a.CreatedOnUtc < cutoff)
+                .ToListAsync();
+
+            foreach (var attempt in staleAttempts)
+            {
+                var order = await _orderService.GetOrderByIdAsync(attempt.OrderId);
+                if (order == null)
+                    continue;
+
+                //one last authoritative pull - covers the case where the payment actually
+                //succeeded but the customer's browser never made it back to BackURL
+                var result = await _ameriaVPosPaymentService.ResolvePaymentAsync(order);
+                if (result.Resolved)
+                    continue;
+
+                //still unresolved after the timeout - give up, restore the cart, matching
+                //Idram's Fail() action for the equivalent web redirect-failure case
+                var freshAttempt = await _attemptRepository.GetByIdAsync(attempt.Id);
+                if (freshAttempt == null || freshAttempt.Status != AmeriaVPosPaymentAttemptStatus.Redirected)
+                    continue;
+
+                freshAttempt.Status = AmeriaVPosPaymentAttemptStatus.Abandoned;
+                freshAttempt.ResolvedOnUtc = DateTime.UtcNow;
+                await _attemptRepository.UpdateAsync(freshAttempt);
+
+                await _logger.InformationAsync(
+                    $"AmeriaVPos: order {order.Id} attempt {attempt.Id} abandoned after " +
+                    $"{_ameriaVPosSettings.AbandonedAttemptTimeoutMinutes} minutes with no resolution - restoring cart.");
+
+                await _orderProcessingService.ReOrderAsync(order);
+                await _orderProcessingService.DeleteOrderAsync(order);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosApiClient.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosApiClient.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Net.Http.Headers;
+using Nop.Core;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Services
+{
+    /// <summary>
+    /// Represents the HTTP client to request AmeriaBank vPOS 3.1 REST services
+    /// </summary>
+    public class AmeriaVPosApiClient
+    {
+        #region Fields
+
+        private readonly HttpClient _httpClient;
+        private readonly AmeriaVPosSettings _ameriaVPosSettings;
+        private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosApiClient(HttpClient client, AmeriaVPosSettings ameriaVPosSettings)
+        {
+            client.Timeout = TimeSpan.FromSeconds(30);
+            client.DefaultRequestHeaders.Add(HeaderNames.UserAgent, $"nopCommerce-{NopVersion.CURRENT_VERSION}");
+
+            _httpClient = client;
+            _ameriaVPosSettings = ameriaVPosSettings;
+        }
+
+        #endregion
+
+        #region Utilities
+
+        /// <summary>
+        /// Base URL for the hosted pay page the customer is redirected to (admin-configured -
+        /// AmeriaBank has not issued a production hostname yet, only the sandbox one)
+        /// </summary>
+        public string PayBaseUrl => _ameriaVPosSettings.PayBaseUrl;
+
+        private async Task<TResponse> PostAsync<TRequest, TResponse>(string action, TRequest request)
+        {
+            var response = await _httpClient.PostAsJsonAsync($"{_ameriaVPosSettings.ApiBaseUrl}/api/VPOS/{action}", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<TResponse>(_jsonOptions);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public Task<InitPaymentResponse> InitPaymentAsync(InitPaymentRequest request) =>
+            PostAsync<InitPaymentRequest, InitPaymentResponse>("InitPayment", request);
+
+        public Task<PaymentDetailsResponse> GetPaymentDetailsAsync(PaymentDetailsRequest request) =>
+            PostAsync<PaymentDetailsRequest, PaymentDetailsResponse>("GetPaymentDetails", request);
+
+        public Task<VPosActionResponse> RefundPaymentAsync(RefundPaymentRequest request) =>
+            PostAsync<RefundPaymentRequest, VPosActionResponse>("RefundPayment", request);
+
+        public Task<VPosActionResponse> CancelPaymentAsync(CancelPaymentRequest request) =>
+            PostAsync<CancelPaymentRequest, VPosActionResponse>("CancelPayment", request);
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosApiModels.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosApiModels.cs
@@ -1,0 +1,64 @@
+namespace Nop.Plugin.Payments.AmeriaVPos.Services
+{
+    public class InitPaymentRequest
+    {
+        public string ClientID { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string Currency { get; set; }
+        public string Description { get; set; }
+        public int OrderID { get; set; }
+        public decimal Amount { get; set; }
+        public string BackURL { get; set; }
+    }
+
+    public class InitPaymentResponse
+    {
+        public string PaymentID { get; set; }
+        public int ResponseCode { get; set; }
+        public string ResponseMessage { get; set; }
+    }
+
+    public class PaymentDetailsRequest
+    {
+        public string PaymentID { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+
+    public class PaymentDetailsResponse
+    {
+        public decimal Amount { get; set; }
+        public decimal DepositedAmount { get; set; }
+        public decimal RefundedAmount { get; set; }
+        public string OrderID { get; set; }
+        public string PaymentState { get; set; }
+        public string OrderStatus { get; set; }
+        public string ResponseCode { get; set; }
+        public string Rrn { get; set; }
+    }
+
+    public class RefundPaymentRequest
+    {
+        public string PaymentID { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public decimal Amount { get; set; }
+    }
+
+    public class CancelPaymentRequest
+    {
+        public string PaymentID { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+
+    /// <summary>
+    /// Shared response shape for RefundPayment/CancelPayment - both only carry a response code/message
+    /// </summary>
+    public class VPosActionResponse
+    {
+        public string ResponseCode { get; set; }
+        public string ResponseMessage { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
@@ -127,7 +127,9 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
             };
             await _attemptRepository.InsertAsync(attempt);
 
-            var backUrl = $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?orderId={order.Id}";
+            //"msOrderId", not "orderId" - collides with AmeriaBank's own OrderID field on
+            //their return redirect, see the comment on BackUrlReturn
+            var backUrl = $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?msOrderId={order.Id}";
 
             var initResponse = await _apiClient.InitPaymentAsync(new InitPaymentRequest
             {

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
@@ -19,6 +19,9 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
     /// </summary>
     public class AmeriaVPosPaymentService : IAmeriaVPosPaymentService
     {
+        //See the comment where this is used (OrderID = AmeriaVPosOrderIdOffset + attempt.Id).
+        private const int AmeriaVPosOrderIdOffset = 900_000_000;
+
         #region Fields
 
         private readonly ICustomerService _customerService;
@@ -144,7 +147,14 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
                 Username = _ameriaVPosSettings.Username,
                 Password = _ameriaVPosSettings.Password,
                 Amount = amountDue,
-                OrderID = attempt.Id,
+                //Offset well clear of small numbers - AmeriaBank's sandbox rejected a raw
+                //small attempt.Id ("Order number is duplicated...") even though it was a
+                //freshly-inserted, never-before-used row on our side, suggesting the
+                //sandbox's OrderID space may be shared across multiple integrators testing
+                //against the same merchant credentials. A large offset (already confirmed
+                //to work fine during Phase 0 verification, see OrderID 900001) avoids
+                //colliding with anyone else's small sequential test IDs.
+                OrderID = AmeriaVPosOrderIdOffset + attempt.Id,
                 Currency = "051",
                 Description = $"MySnacks order #{order.Id}",
                 BackURL = backUrl

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
@@ -324,7 +324,17 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
             attempt.Status = AmeriaVPosPaymentAttemptStatus.Cancelled;
             await _attemptRepository.UpdateAsync(attempt);
 
-            await _orderProcessingService.VoidOfflineAsync(order);
+            //Not VoidOfflineAsync: nopCommerce's CanVoidOffline requires
+            //PaymentStatus.Authorized, but AmeriaVPos is a single-stage
+            //capture - the order goes straight from Pending to Paid and is
+            //never Authorized, so VoidOfflineAsync would always throw here.
+            //RefundOfflineAsync (CanRefundOffline requires Paid) is the
+            //nopCommerce-level effect that actually matches: money went back
+            //to the customer, same as RefundAsync above. The distinction
+            //between AmeriaBank's Cancel and Refund APIs is a bank-side
+            //same-day-vs-settled distinction only - nopCommerce has no
+            //separate order status for it.
+            await _orderProcessingService.RefundOfflineAsync(order);
 
             return true;
         }

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
@@ -97,10 +97,14 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
             //null means "nothing to draw against" here (zero limit, Allowance Excempt role, or
             //no company at all) - not an error, just the same as RemainingAllowance == 0
             var remainingAllowance = balance?.RemainingAllowance ?? 0M;
-            var amountCoveredByAllowance = Math.Min(Math.Max(remainingAllowance, 0M), order.OrderTotal);
-            var amountDue = order.OrderTotal - amountCoveredByAllowance;
 
-            if (amountDue <= 0)
+            //An order is never split between allowance and card - per-company invoice
+            //reconciliation attributes a whole order to one payer or the other (a
+            //completed AmeriaVPos charge >0 excludes the ENTIRE order from that company's
+            //allowance invoice), so a partial allowance/partial card charge would silently
+            //under-bill the company for the portion it actually covered. If the allowance
+            //can't cover the full order, none of it is drawn - the whole total goes to card.
+            if (remainingAllowance >= order.OrderTotal)
             {
                 //fully covered - mark paid the proper way (not a raw field flip) so
                 //ProcessOrderPaidAsync runs: vendor notification, reward points, etc.
@@ -113,6 +117,9 @@ namespace Nop.Plugin.Payments.AmeriaVPos.Services
                     AmountCoveredByAllowance = order.OrderTotal
                 };
             }
+
+            var amountCoveredByAllowance = 0M;
+            var amountDue = order.OrderTotal;
 
             var attemptNumber = await _attemptRepository.Table.Where(a => a.OrderId == order.Id).CountAsync() + 1;
 

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Services/AmeriaVPosPaymentService.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nop.Core;
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Payments;
+using Nop.Data;
+using Nop.Plugin.Payments.AmeriaVPos.Domain;
+using Nop.Services.Customers;
+using Nop.Services.Logging;
+using Nop.Services.Orders;
+using Nop.Services.Payments;
+
+namespace Nop.Plugin.Payments.AmeriaVPos.Services
+{
+    /// <summary>
+    /// Core AmeriaBank vPOS payment logic - see IAmeriaVPosPaymentService for why this is
+    /// shared between the web IPaymentMethod flow and the mobile order-confirmation API.
+    /// </summary>
+    public class AmeriaVPosPaymentService : IAmeriaVPosPaymentService
+    {
+        #region Fields
+
+        private readonly ICustomerService _customerService;
+        private readonly ICompanyAllowancePaymentMethod _companyAllowancePaymentMethod;
+        private readonly IOrderService _orderService;
+        private readonly IOrderProcessingService _orderProcessingService;
+        private readonly IRepository<AmeriaVPosPaymentAttempt> _attemptRepository;
+        private readonly IWebHelper _webHelper;
+        private readonly AmeriaVPosSettings _ameriaVPosSettings;
+        private readonly AmeriaVPosApiClient _apiClient;
+        private readonly ILogger _logger;
+
+        #endregion
+
+        #region Ctor
+
+        public AmeriaVPosPaymentService(
+            ICustomerService customerService,
+            ICompanyAllowancePaymentMethod companyAllowancePaymentMethod,
+            IOrderService orderService,
+            IOrderProcessingService orderProcessingService,
+            IRepository<AmeriaVPosPaymentAttempt> attemptRepository,
+            IWebHelper webHelper,
+            AmeriaVPosSettings ameriaVPosSettings,
+            AmeriaVPosApiClient apiClient,
+            ILogger logger)
+        {
+            _customerService = customerService;
+            _companyAllowancePaymentMethod = companyAllowancePaymentMethod;
+            _orderService = orderService;
+            _orderProcessingService = orderProcessingService;
+            _attemptRepository = attemptRepository;
+            _webHelper = webHelper;
+            _ameriaVPosSettings = ameriaVPosSettings;
+            _apiClient = apiClient;
+            _logger = logger;
+        }
+
+        #endregion
+
+        #region Utilities
+
+        private async Task<AmeriaVPosPaymentAttempt> GetLatestAttemptAsync(int orderId)
+        {
+            return await _attemptRepository.Table
+                .Where(a => a.OrderId == orderId)
+                .OrderByDescending(a => a.Id)
+                .FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Maps an AmeriaBank Table-2 PaymentState to our attempt status. Unknown/unset
+        /// states (payment_started, payment_approved, payment_autoauthorized - none of
+        /// which apply to a single-stage, non-binding integration) stay Redirected.
+        /// </summary>
+        private static AmeriaVPosPaymentAttemptStatus MapPaymentState(string paymentState) => paymentState switch
+        {
+            "payment_deposited" => AmeriaVPosPaymentAttemptStatus.Paid,
+            "payment_declined" => AmeriaVPosPaymentAttemptStatus.Declined,
+            "payment_refunded" => AmeriaVPosPaymentAttemptStatus.Refunded,
+            "payment_void" => AmeriaVPosPaymentAttemptStatus.Cancelled,
+            _ => AmeriaVPosPaymentAttemptStatus.Redirected
+        };
+
+        #endregion
+
+        #region Methods
+
+        public async Task<AmeriaVPosPaymentResult> InitiateOrCompletePaymentAsync(Order order, string platform = "Web")
+        {
+            var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+
+            var balance = await _companyAllowancePaymentMethod.GetCustomerRemainingAllowance(
+                new CustomerBalanceRequest { Customer = customer, OrderDateUtc = order.ScheduleDate });
+
+            //null means "nothing to draw against" here (zero limit, Allowance Excempt role, or
+            //no company at all) - not an error, just the same as RemainingAllowance == 0
+            var remainingAllowance = balance?.RemainingAllowance ?? 0M;
+            var amountCoveredByAllowance = Math.Min(Math.Max(remainingAllowance, 0M), order.OrderTotal);
+            var amountDue = order.OrderTotal - amountCoveredByAllowance;
+
+            if (amountDue <= 0)
+            {
+                //fully covered - mark paid the proper way (not a raw field flip) so
+                //ProcessOrderPaidAsync runs: vendor notification, reward points, etc.
+                await _orderProcessingService.MarkOrderAsPaidAsync(order);
+
+                return new AmeriaVPosPaymentResult
+                {
+                    RequiresPayment = false,
+                    AmountDue = 0M,
+                    AmountCoveredByAllowance = order.OrderTotal
+                };
+            }
+
+            var attemptNumber = await _attemptRepository.Table.Where(a => a.OrderId == order.Id).CountAsync() + 1;
+
+            var attempt = new AmeriaVPosPaymentAttempt
+            {
+                OrderId = order.Id,
+                AttemptNumber = attemptNumber,
+                RequestedAmount = amountDue,
+                Status = AmeriaVPosPaymentAttemptStatus.Started,
+                Platform = platform,
+                CreatedOnUtc = DateTime.UtcNow
+            };
+            await _attemptRepository.InsertAsync(attempt);
+
+            var backUrl = $"{_webHelper.GetStoreLocation()}ameriavpos/backurlreturn?orderId={order.Id}";
+
+            var initResponse = await _apiClient.InitPaymentAsync(new InitPaymentRequest
+            {
+                ClientID = _ameriaVPosSettings.ClientId,
+                Username = _ameriaVPosSettings.Username,
+                Password = _ameriaVPosSettings.Password,
+                Amount = amountDue,
+                OrderID = attempt.Id,
+                Currency = "051",
+                Description = $"MySnacks order #{order.Id}",
+                BackURL = backUrl
+            });
+
+            if (initResponse?.ResponseCode != 1)
+            {
+                await _logger.ErrorAsync(
+                    $"AmeriaVPos InitPayment failed for order {order.Id}, attempt {attempt.Id}: " +
+                    $"{initResponse?.ResponseCode} {initResponse?.ResponseMessage}");
+                attempt.Status = AmeriaVPosPaymentAttemptStatus.Declined;
+                attempt.ResolvedOnUtc = DateTime.UtcNow;
+                await _attemptRepository.UpdateAsync(attempt);
+
+                return new AmeriaVPosPaymentResult
+                {
+                    RequiresPayment = true,
+                    AmountDue = amountDue,
+                    AmountCoveredByAllowance = amountCoveredByAllowance,
+                    Status = attempt.Status.ToString(),
+                    Platform = attempt.Platform
+                };
+            }
+
+            attempt.PaymentId = initResponse.PaymentID;
+            attempt.Status = AmeriaVPosPaymentAttemptStatus.Redirected;
+            await _attemptRepository.UpdateAsync(attempt);
+
+            var paymentUrl = $"{_apiClient.PayBaseUrl}/Payments/Pay?id={initResponse.PaymentID}&lang=en";
+
+            return new AmeriaVPosPaymentResult
+            {
+                RequiresPayment = true,
+                PaymentUrl = paymentUrl,
+                AmountDue = amountDue,
+                AmountCoveredByAllowance = amountCoveredByAllowance,
+                Status = attempt.Status.ToString(),
+                Platform = attempt.Platform
+            };
+        }
+
+        public async Task<AmeriaVPosPaymentResult> GetLatestAttemptStatusAsync(Order order)
+        {
+            var attempt = await GetLatestAttemptAsync(order.Id);
+            if (attempt == null)
+                return new AmeriaVPosPaymentResult { Status = AmeriaVPosPaymentAttemptStatus.Started.ToString() };
+
+            return new AmeriaVPosPaymentResult
+            {
+                Status = attempt.Status.ToString(),
+                AmountDue = attempt.RequestedAmount,
+                Resolved = attempt.ResolvedOnUtc.HasValue,
+                Platform = attempt.Platform
+            };
+        }
+
+        public async Task<AmeriaVPosPaymentResult> ResolvePaymentAsync(Order order)
+        {
+            var attempt = await GetLatestAttemptAsync(order.Id);
+            if (attempt == null || string.IsNullOrEmpty(attempt.PaymentId))
+                return new AmeriaVPosPaymentResult { Status = AmeriaVPosPaymentAttemptStatus.Started.ToString() };
+
+            if (attempt.ResolvedOnUtc.HasValue)
+                return new AmeriaVPosPaymentResult
+                {
+                    Status = attempt.Status.ToString(),
+                    AmountDue = attempt.RequestedAmount,
+                    Resolved = true,
+                    Platform = attempt.Platform
+                };
+
+            var details = await _apiClient.GetPaymentDetailsAsync(new PaymentDetailsRequest
+            {
+                PaymentID = attempt.PaymentId,
+                Username = _ameriaVPosSettings.Username,
+                Password = _ameriaVPosSettings.Password
+            });
+
+            var newStatus = MapPaymentState(details?.PaymentState);
+
+            if (newStatus == AmeriaVPosPaymentAttemptStatus.Paid)
+            {
+                //never trust the amount from the redirect - only from this authoritative pull
+                attempt.ChargedAmount = details.DepositedAmount;
+                attempt.Rrn = details.Rrn;
+                attempt.Status = AmeriaVPosPaymentAttemptStatus.Paid;
+                attempt.ResolvedOnUtc = DateTime.UtcNow;
+                await _attemptRepository.UpdateAsync(attempt);
+
+                //order.OrderTotal was never reduced - the allowance already covered the rest,
+                //so a successful card charge for the shortfall means the whole order is paid
+                await _orderProcessingService.MarkOrderAsPaidAsync(order);
+            }
+            else if (newStatus == AmeriaVPosPaymentAttemptStatus.Declined)
+            {
+                attempt.Status = AmeriaVPosPaymentAttemptStatus.Declined;
+                attempt.ResolvedOnUtc = DateTime.UtcNow;
+                await _attemptRepository.UpdateAsync(attempt);
+
+                //restore the cart, mirroring Idram's Fail() action - the order stays Pending
+                //forever otherwise, with an already-emptied cart and no easy way to retry
+                await _orderProcessingService.ReOrderAsync(order);
+                await _orderProcessingService.DeleteOrderAsync(order);
+            }
+
+            return new AmeriaVPosPaymentResult
+            {
+                Status = attempt.Status.ToString(),
+                AmountDue = attempt.RequestedAmount,
+                Resolved = attempt.ResolvedOnUtc.HasValue,
+                Platform = attempt.Platform
+            };
+        }
+
+        public async Task<bool> RefundAsync(Order order, decimal amount)
+        {
+            var attempt = await GetLatestAttemptAsync(order.Id);
+            if (attempt?.Status != AmeriaVPosPaymentAttemptStatus.Paid)
+                return false;
+
+            var response = await _apiClient.RefundPaymentAsync(new RefundPaymentRequest
+            {
+                PaymentID = attempt.PaymentId,
+                Username = _ameriaVPosSettings.Username,
+                Password = _ameriaVPosSettings.Password,
+                Amount = amount
+            });
+
+            if (response?.ResponseCode != "00")
+            {
+                await _logger.ErrorAsync(
+                    $"AmeriaVPos RefundPayment failed for order {order.Id}: {response?.ResponseCode} {response?.ResponseMessage}");
+                return false;
+            }
+
+            attempt.Status = AmeriaVPosPaymentAttemptStatus.Refunded;
+            await _attemptRepository.UpdateAsync(attempt);
+
+            if (amount >= order.OrderTotal)
+                await _orderProcessingService.RefundOfflineAsync(order);
+            else
+                await _orderProcessingService.PartiallyRefundOfflineAsync(order, amount);
+
+            return true;
+        }
+
+        public async Task<bool> CancelAsync(Order order)
+        {
+            var attempt = await GetLatestAttemptAsync(order.Id);
+            if (attempt?.Status != AmeriaVPosPaymentAttemptStatus.Paid)
+                return false;
+
+            var response = await _apiClient.CancelPaymentAsync(new CancelPaymentRequest
+            {
+                PaymentID = attempt.PaymentId,
+                Username = _ameriaVPosSettings.Username,
+                Password = _ameriaVPosSettings.Password
+            });
+
+            if (response?.ResponseCode != "00")
+            {
+                await _logger.ErrorAsync(
+                    $"AmeriaVPos CancelPayment failed for order {order.Id}: {response?.ResponseCode} {response?.ResponseMessage}");
+                return false;
+            }
+
+            attempt.Status = AmeriaVPosPaymentAttemptStatus.Cancelled;
+            await _attemptRepository.UpdateAsync(attempt);
+
+            await _orderProcessingService.VoidOfflineAsync(order);
+
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/Configure.cshtml
@@ -1,0 +1,80 @@
+@model Nop.Plugin.Payments.AmeriaVPos.Models.ConfigurationModel
+@{
+    Layout = "_ConfigurePlugin";
+}
+
+@await Component.InvokeAsync("StoreScopeConfiguration")
+
+<form asp-controller="AmeriaVPos" asp-action="Configure" method="post">
+    <div class="cards-group">
+        <div class="card card-default">
+            <div class="card-body">
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="UseSandbox_OverrideForStore" asp-input="UseSandbox" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="UseSandbox" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="UseSandbox" />
+                        <span asp-validation-for="UseSandbox"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="ClientId_OverrideForStore" asp-input="ClientId" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="ClientId" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="ClientId" />
+                        <span asp-validation-for="ClientId"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="Username_OverrideForStore" asp-input="Username" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="Username" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="Username" />
+                        <span asp-validation-for="Username"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="Password_OverrideForStore" asp-input="Password" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="Password" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="Password" />
+                        <span asp-validation-for="Password"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="ApiBaseUrl_OverrideForStore" asp-input="ApiBaseUrl" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="ApiBaseUrl" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="ApiBaseUrl" />
+                        <span asp-validation-for="ApiBaseUrl"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3">
+                        <nop-override-store-checkbox asp-for="PayBaseUrl_OverrideForStore" asp-input="PayBaseUrl" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                        <nop-label asp-for="PayBaseUrl" />
+                    </div>
+                    <div class="col-md-9">
+                        <nop-editor asp-for="PayBaseUrl" />
+                        <span asp-validation-for="PayBaseUrl"></span>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-9 offset-md-3">
+                        <button type="submit" name="save" class="btn btn-primary">@T("Admin.Common.Save")</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/MobileReturn.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/MobileReturn.cshtml
@@ -1,0 +1,20 @@
+@model int
+@{
+    Layout = null;
+    var deepLinkUrl = $"mysnacks://payment-callback?orderId={Model}";
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>MySnacks</title>
+    <meta http-equiv="refresh" content="0;url=@deepLinkUrl" />
+    <script>
+        window.location.href = "@deepLinkUrl";
+    </script>
+</head>
+<body style="font-family: sans-serif; text-align: center; padding-top: 60px;">
+    <p>Returning you to the MySnacks app&hellip;</p>
+    <p><a href="@deepLinkUrl">Tap here if you're not redirected automatically</a></p>
+</body>
+</html>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
@@ -8,7 +8,15 @@
         <p>
             @string.Format(T("Plugins.Payments.AmeriaVPos.OrderActions.ChargedAmount").Text, Model.ChargedAmount)
         </p>
-        <form asp-controller="AmeriaVPos" asp-action="RefundAmeriaPayment" method="post" class="form-inline" style="display:inline-block; margin-right: 10px;">
+        @* asp-area="Admin" is required here even though the controller/action are
+           area-scoped ([Area(AreaNames.Admin)]) and this partial is only ever
+           rendered inside an Admin-area page: ASP.NET Core's convention-based area
+           inference comes from the VIEW's own file path being under Areas/Admin/,
+           not from the page it's embedded in. This view lives in the plugin's own
+           Views/ folder (rendered into Order/Edit via a widget zone), so without an
+           explicit asp-area the tag helper can't find a matching route and the form
+           silently falls back to posting to the current page. *@
+        <form asp-controller="AmeriaVPos" asp-action="RefundAmeriaPayment" asp-area="Admin" method="post" class="form-inline" style="display:inline-block; margin-right: 10px;">
             <input type="hidden" name="orderId" value="@Model.OrderId" />
             <div class="form-group">
                 <label for="ameria-refund-amount">@T("Plugins.Payments.AmeriaVPos.OrderActions.RefundAmount")</label>
@@ -24,7 +32,7 @@
             </button>
             <nop-action-confirmation asp-button-id="refundameriapayment" />
         </form>
-        <form asp-controller="AmeriaVPos" asp-action="CancelAmeriaPayment" method="post" style="display:inline-block;">
+        <form asp-controller="AmeriaVPos" asp-action="CancelAmeriaPayment" asp-area="Admin" method="post" style="display:inline-block;">
             <input type="hidden" name="orderId" value="@Model.OrderId" />
             <button type="submit" name="cancelameriapayment" id="cancelameriapayment" class="btn btn-danger">
                 @T("Plugins.Payments.AmeriaVPos.OrderActions.Cancel")

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
@@ -50,10 +50,18 @@
                 type: 'POST',
                 data: $.extend({ __RequestVerificationToken: token }, extraData),
                 success: function () {
+                    // The controller always redirects back to Edit (200 after
+                    // redirect) whether the AmeriaBank call succeeded or failed -
+                    // success/error notification is a banner baked into that
+                    // reloaded page, not an HTTP status. Reload shows it either way.
                     location.reload();
                 },
                 error: function (xhr) {
-                    alert(xhr.responseText || 'Request failed');
+                    // Only genuine transport failures land here (network error,
+                    // antiforgery rejection, unhandled 500). Never surface
+                    // xhr.responseText directly - it can be a raw HTML error page.
+                    console.error('AmeriaVPos action failed', xhr.status, xhr.responseText);
+                    alert('Request failed (' + xhr.status + '). Check the browser console or server log for details.');
                 }
             });
         }

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
@@ -12,7 +12,12 @@
             <input type="hidden" name="orderId" value="@Model.OrderId" />
             <div class="form-group">
                 <label for="ameria-refund-amount">@T("Plugins.Payments.AmeriaVPos.OrderActions.RefundAmount")</label>
-                <input type="number" step="0.01" min="0" max="@Model.ChargedAmount" name="amount" id="ameria-refund-amount" value="@Model.ChargedAmount" class="form-control" style="width: 120px; margin: 0 8px;" />
+                @* step="any" - not stricter (e.g. "0.01") - a browser's native step-mismatch
+                   check compares in floating point, so a pre-filled value with more decimal
+                   places than the DB column's precision (e.g. ChargedAmount's raw "10.0000")
+                   can false-positive as "not a multiple of 0.01" and silently block the whole
+                   form from submitting, even on a mathematically valid amount. *@
+                <input type="number" step="any" min="0" max="@Model.ChargedAmount" name="amount" id="ameria-refund-amount" value="@Model.ChargedAmount" class="form-control" style="width: 120px; margin: 0 8px;" />
             </div>
             <button type="submit" name="refundameriapayment" id="refundameriapayment" class="btn btn-primary">
                 @T("Plugins.Payments.AmeriaVPos.OrderActions.Refund")

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
@@ -1,0 +1,30 @@
+@model Nop.Plugin.Payments.AmeriaVPos.Models.AmeriaVPosOrderActionsModel
+
+<div class="card card-default">
+    <div class="card-header">
+        @T("Plugins.Payments.AmeriaVPos.OrderActions.Title")
+    </div>
+    <div class="card-body">
+        <p>
+            @string.Format(T("Plugins.Payments.AmeriaVPos.OrderActions.ChargedAmount").Text, Model.ChargedAmount)
+        </p>
+        <form asp-controller="AmeriaVPos" asp-action="RefundAmeriaPayment" method="post" class="form-inline" style="display:inline-block; margin-right: 10px;">
+            <input type="hidden" name="orderId" value="@Model.OrderId" />
+            <div class="form-group">
+                <label for="ameria-refund-amount">@T("Plugins.Payments.AmeriaVPos.OrderActions.RefundAmount")</label>
+                <input type="number" step="0.01" min="0" max="@Model.ChargedAmount" name="amount" id="ameria-refund-amount" value="@Model.ChargedAmount" class="form-control" style="width: 120px; margin: 0 8px;" />
+            </div>
+            <button type="submit" name="refundameriapayment" id="refundameriapayment" class="btn btn-primary">
+                @T("Plugins.Payments.AmeriaVPos.OrderActions.Refund")
+            </button>
+            <nop-action-confirmation asp-button-id="refundameriapayment" />
+        </form>
+        <form asp-controller="AmeriaVPos" asp-action="CancelAmeriaPayment" method="post" style="display:inline-block;">
+            <input type="hidden" name="orderId" value="@Model.OrderId" />
+            <button type="submit" name="cancelameriapayment" id="cancelameriapayment" class="btn btn-danger">
+                @T("Plugins.Payments.AmeriaVPos.OrderActions.Cancel")
+            </button>
+            <nop-action-confirmation asp-button-id="cancelameriapayment" />
+        </form>
+    </div>
+</div>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/OrderActions/OrderActions.cshtml
@@ -8,16 +8,7 @@
         <p>
             @string.Format(T("Plugins.Payments.AmeriaVPos.OrderActions.ChargedAmount").Text, Model.ChargedAmount)
         </p>
-        @* asp-area="Admin" is required here even though the controller/action are
-           area-scoped ([Area(AreaNames.Admin)]) and this partial is only ever
-           rendered inside an Admin-area page: ASP.NET Core's convention-based area
-           inference comes from the VIEW's own file path being under Areas/Admin/,
-           not from the page it's embedded in. This view lives in the plugin's own
-           Views/ folder (rendered into Order/Edit via a widget zone), so without an
-           explicit asp-area the tag helper can't find a matching route and the form
-           silently falls back to posting to the current page. *@
-        <form asp-controller="AmeriaVPos" asp-action="RefundAmeriaPayment" asp-area="Admin" method="post" class="form-inline" style="display:inline-block; margin-right: 10px;">
-            <input type="hidden" name="orderId" value="@Model.OrderId" />
+        <div class="form-inline" style="display:inline-block; margin-right: 10px;">
             <div class="form-group">
                 <label for="ameria-refund-amount">@T("Plugins.Payments.AmeriaVPos.OrderActions.RefundAmount")</label>
                 @* step="any" - not stricter (e.g. "0.01") - a browser's native step-mismatch
@@ -25,19 +16,61 @@
                    places than the DB column's precision (e.g. ChargedAmount's raw "10.0000")
                    can false-positive as "not a multiple of 0.01" and silently block the whole
                    form from submitting, even on a mathematically valid amount. *@
-                <input type="number" step="any" min="0" max="@Model.ChargedAmount" name="amount" id="ameria-refund-amount" value="@Model.ChargedAmount" class="form-control" style="width: 120px; margin: 0 8px;" />
+                <input type="number" step="any" min="0" max="@Model.ChargedAmount" id="ameria-refund-amount" value="@Model.ChargedAmount" class="form-control" style="width: 120px; margin: 0 8px;" />
             </div>
-            <button type="submit" name="refundameriapayment" id="refundameriapayment" class="btn btn-primary">
+            <button type="button" id="refundameriapayment" class="btn btn-primary">
                 @T("Plugins.Payments.AmeriaVPos.OrderActions.Refund")
             </button>
             <nop-action-confirmation asp-button-id="refundameriapayment" />
-        </form>
-        <form asp-controller="AmeriaVPos" asp-action="CancelAmeriaPayment" asp-area="Admin" method="post" style="display:inline-block;">
-            <input type="hidden" name="orderId" value="@Model.OrderId" />
-            <button type="submit" name="cancelameriapayment" id="cancelameriapayment" class="btn btn-danger">
-                @T("Plugins.Payments.AmeriaVPos.OrderActions.Cancel")
-            </button>
-            <nop-action-confirmation asp-button-id="cancelameriapayment" />
-        </form>
+        </div>
+        <button type="button" id="cancelameriapayment" class="btn btn-danger">
+            @T("Plugins.Payments.AmeriaVPos.OrderActions.Cancel")
+        </button>
+        <nop-action-confirmation asp-button-id="cancelameriapayment" />
     </div>
 </div>
+
+@* These actions POST via AJAX rather than a <form>: this partial is rendered
+   via a widget zone inside Order/Edit's own page-wide <form id="order-form">,
+   and HTML forbids nesting <form> elements - the browser silently drops a
+   nested opening <form> tag while parsing, so any button inside always ends
+   up submitting the OUTER order-form instead (confirmed live: the button's
+   closest('form') was Order/Edit's own form, action /Admin/Order/Edit/{id},
+   no matter what asp-controller/asp-action/asp-area was set on our own
+   <form>). AJAX to the existing AmeriaVPosController actions sidesteps the
+   nesting problem entirely - same pattern Admin/Shared/Table.cshtml's grids
+   use, reading the shared __RequestVerificationToken input rather than
+   relying on form membership. *@
+<script>
+    $(document).ready(function () {
+        function postAmeriaAction(url, extraData) {
+            var token = $('input[name=__RequestVerificationToken]').val();
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: $.extend({ __RequestVerificationToken: token }, extraData),
+                success: function () {
+                    location.reload();
+                },
+                error: function (xhr) {
+                    alert(xhr.responseText || 'Request failed');
+                }
+            });
+        }
+
+        $('#refundameriapayment-action-confirmation-submit-button').on('click', function (e) {
+            e.preventDefault();
+            postAmeriaAction('@Url.Action("RefundAmeriaPayment", "AmeriaVPos", new { area = "Admin" })', {
+                orderId: @Model.OrderId,
+                amount: $('#ameria-refund-amount').val()
+            });
+        });
+
+        $('#cancelameriapayment-action-confirmation-submit-button').on('click', function (e) {
+            e.preventDefault();
+            postAmeriaAction('@Url.Action("CancelAmeriaPayment", "AmeriaVPos", new { area = "Admin" })', {
+                orderId: @Model.OrderId
+            });
+        });
+    });
+</script>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/PaymentFail.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/PaymentFail.cshtml
@@ -1,0 +1,22 @@
+@{
+    Layout = "_ColumnsOne";
+
+    Html.AddTitleParts(T("Plugins.Payments.AmeriaVPos.PageTitle.Fail").Text);
+    Html.AppendPageCssClassParts("html-checkout-page");
+    Html.AppendPageCssClassParts("html-order-completed-page");
+}
+<div class="page checkout-page order-completed-page">
+    <div class="page-title">
+        <h1>@T("Plugins.Payments.AmeriaVPos.Checkout.Fail")</h1>
+    </div>
+    <div class="page-body checkout-data">
+        <div class="section order-completed">
+            <div class="title">
+                <strong>@T("Plugins.Payments.AmeriaVPos.Checkout.YourPaymentHasBeenFailed")</strong>
+            </div>
+            <div class="buttons">
+                <button type="button" class="button-1 order-completed-continue-button" onclick="setLocation('@Url.RouteUrl("Checkout")')">@T("Plugins.Payments.AmeriaVPos.Checkout.Error.Continue")</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/_ViewImports.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/Views/_ViewImports.cshtml
@@ -1,0 +1,8 @@
+@inherits Nop.Web.Framework.Mvc.Razor.NopRazorPage<TModel>
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Nop.Web.Framework
+
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@using Nop.Web.Framework.UI
+@using Nop.Web.Framework.Extensions
+@using System.Text.Encodings.Web

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/plugin.json
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/plugin.json
@@ -1,0 +1,11 @@
+{
+  "Group": "Payment methods",
+  "FriendlyName": "AmeriaBank vPOS",
+  "SystemName": "Payments.AmeriaVPos",
+  "Version": "1.0",
+  "SupportedVersions": [ "4.50" ],
+  "Author": "Custom",
+  "DisplayOrder": 1,
+  "FileName": "Nop.Plugin.Payments.AmeriaVPos.dll",
+  "Description": "This plugin allows paying by card via AmeriaBank vPOS"
+}

--- a/src/Plugins/Nop.Plugin.Payments.CheckMoneyOrder/CheckMoneyOrderPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.CheckMoneyOrder/CheckMoneyOrderPaymentProcessor.cs
@@ -36,8 +36,6 @@ namespace Nop.Plugin.Payments.CheckMoneyOrder
         ICompanyAllowancePaymentMethod,
         IWidgetPlugin
     {
-        // keep in sync with IdramMerchantPaymentProcessor.CompanyBenefitExemptionRole
-        private const string CompanyBenefitExemptionRole = "Allowance Excempt";
         private const string UnlimitedAccountRoleSystemName = "UnlimitedAccount";
         private const string VoidedAllowancesSettingsKey = "VoidedAllowancesSettings";
         // keep in sync with Nop.Plugin.Company.Company DeliveryTimeStorageService.SELECTED_DELIVERY_TIME_KEY
@@ -597,7 +595,7 @@ namespace Nop.Plugin.Payments.CheckMoneyOrder
             var customerRoles = await _customerService.GetCustomerRolesAsync(customer);
 
             if (customerRoles.Any(role =>
-                    string.Equals(role.Name, CompanyBenefitExemptionRole, StringComparison.OrdinalIgnoreCase)))
+                    string.Equals(role.Name, NopCustomerDefaults.CompanyBenefitExemptionRoleName, StringComparison.OrdinalIgnoreCase)))
                 return (AmountLimitType.Daily, 0M);
             
             var company = await _companyService.GetCompanyByCustomerIdAsync(customer.Id);

--- a/src/Plugins/Nop.Plugin.Payments.Idram/IdramMerchantPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.Idram/IdramMerchantPaymentProcessor.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Nop.Core;
+using Nop.Core.Domain.Customers;
 using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Payments;
 using Nop.Data;
@@ -32,8 +33,6 @@ namespace Nop.Plugin.Payments.Idram
 {
     public class IdramMerchantPaymentProcessor : BasePlugin, IPaymentMethod, IPlugin
     {
-        // keep in sync with CheckMoneyOrderPaymentProcessor.CompanyBenefitExemptionRole
-        private const string CompanyBenefitExemptionRole = "Allowance Excempt";
         // keep in sync with Nop.Plugin.Company.Company DeliveryTimeStorageService.SELECTED_DELIVERY_TIME_KEY
         private const string SelectedDeliveryTimeAttributeName = "SELECTED_DELIVERY_TIME_KEY";
         
@@ -306,7 +305,7 @@ namespace Nop.Plugin.Payments.Idram
             var customerRoles = await _customerService.GetCustomerRolesAsync(currentCustomer);
 
             if (customerRoles.Any(role =>
-                    string.Equals(role.Name, CompanyBenefitExemptionRole, StringComparison.OrdinalIgnoreCase)))
+                    string.Equals(role.Name, NopCustomerDefaults.CompanyBenefitExemptionRoleName, StringComparison.OrdinalIgnoreCase)))
                 return 0M;
             
             var company = await _companyService.GetCompanyByCustomerIdAsync(currentCustomer.Id);

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -27,6 +27,7 @@ using Nop.Services.Localization;
 using Nop.Services.Logging;
 using Nop.Services.Media.RoxyFileman;
 using Nop.Services.Plugins;
+using Nop.Services.Tasks;
 using Nop.Web.Framework.Globalization;
 using Nop.Web.Framework.Mvc.Routing;
 using WebMarkupMin.AspNetCore5;
@@ -74,6 +75,21 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
             //further actions are performed only when the database is installed
             if (DataSettingsManager.IsDatabaseInstalled())
             {
+                //update nopCommerce core and db FIRST, so everything below runs against a fully-migrated
+                //schema. Moved above TaskManager.Initialize(): it reads ScheduleTask, which now includes
+                //migration-added columns (e.g. CronExpression) that would not yet exist if migrations ran later.
+                var migrationManager = engine.Resolve<IMigrationManager>();
+                var assembly = Assembly.GetAssembly(typeof(ApplicationBuilderExtensions));
+                migrationManager.ApplyUpMigrations(assembly, true);
+                assembly = Assembly.GetAssembly(typeof(IMigrationManager));
+                migrationManager.ApplyUpMigrations(assembly, true);
+
+#if DEBUG
+                //prevent save the update migrations into the DB during the developing process
+                var versions = EngineContext.Current.Resolve<IRepository<MigrationVersionInfo>>();
+                versions.DeleteAsync(mvi => mvi.Description.StartsWith(string.Format(NopMigrationDefaults.UpdateMigrationDescriptionPrefix, NopVersion.FULL_VERSION)));
+#endif
+
                 //initialize and start schedule tasks
                 Services.Tasks.TaskManager.Instance.Initialize();
                 Services.Tasks.TaskManager.Instance.Start();
@@ -86,18 +102,10 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                 pluginService.InstallPluginsAsync().Wait();
                 pluginService.UpdatePluginsAsync().Wait();
 
-                //update nopCommerce core and db
-                var migrationManager = engine.Resolve<IMigrationManager>();
-                var assembly = Assembly.GetAssembly(typeof(ApplicationBuilderExtensions));
-                migrationManager.ApplyUpMigrations(assembly, true);
-                assembly = Assembly.GetAssembly(typeof(IMigrationManager));
-                migrationManager.ApplyUpMigrations(assembly, true);
-
-#if DEBUG
-                //prevent save the update migrations into the DB during the developing process  
-                var versions = EngineContext.Current.Resolve<IRepository<MigrationVersionInfo>>();
-                versions.DeleteAsync(mvi => mvi.Description.StartsWith(string.Format(NopMigrationDefaults.UpdateMigrationDescriptionPrefix, NopVersion.FULL_VERSION)));
-#endif
+                //register dynamic (CRON) schedule tasks with external schedulers (e.g. Hangfire) - after
+                //migrations, so CronExpression is available. No-op when no registrar is registered.
+                foreach (var registrar in engine.ResolveAll<IRecurringTaskRegistrar>())
+                    registrar.RegisterAsync().Wait();
             }
         }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/ScheduleTaskController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/ScheduleTaskController.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Nop.Services.Localization;
 using Nop.Services.Logging;
 using Nop.Services.Messages;
@@ -11,6 +13,7 @@ using Nop.Web.Areas.Admin.Infrastructure.Mapper.Extensions;
 using Nop.Web.Areas.Admin.Models.Tasks;
 using Nop.Web.Framework.Mvc;
 using Nop.Web.Framework.Mvc.ModelBinding;
+using Nop.Web.Infrastructure;
 using Task = Nop.Services.Tasks.Task;
 
 namespace Nop.Web.Areas.Admin.Controllers
@@ -99,6 +102,29 @@ namespace Nop.Web.Areas.Admin.Controllers
                 return ErrorJson(ModelState.SerializeErrors());            
 
             scheduleTask = model.ToEntity(scheduleTask);
+
+            //reconcile the Hangfire recurring job so CRON changes take effect at runtime (no restart needed on
+            //the Hangfire side). Registering also validates the CRON string - Hangfire throws on a bad expression.
+            var recurringJobManager = HttpContext.RequestServices.GetService<IRecurringJobManager>();
+            if (recurringJobManager != null)
+            {
+                var taskType = scheduleTask.Type;
+                try
+                {
+                    if (scheduleTask.Enabled && !string.IsNullOrWhiteSpace(scheduleTask.CronExpression))
+                        recurringJobManager.AddOrUpdate<HangfireScheduleTaskRunner>(taskType,
+                            runner => runner.RunScheduleTaskAsync(taskType), scheduleTask.CronExpression);
+                    else
+                        recurringJobManager.RemoveIfExists(taskType);
+                }
+                catch (Exception ex)
+                {
+                    //most likely an invalid CRON expression - report it and do not persist the change
+                    return ErrorJson(string.Format(
+                        await _localizationService.GetResourceAsync("Admin.System.ScheduleTasks.CronExpression.Invalid"),
+                        ex.Message));
+                }
+            }
 
             await _scheduleTaskService.UpdateTaskAsync(scheduleTask);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Tasks/ScheduleTaskModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Tasks/ScheduleTaskModel.cs
@@ -16,6 +16,9 @@ namespace Nop.Web.Areas.Admin.Models.Tasks
         [NopResourceDisplayName("Admin.System.ScheduleTasks.Seconds")]
         public int Seconds { get; set; }
 
+        [NopResourceDisplayName("Admin.System.ScheduleTasks.CronExpression")]
+        public string CronExpression { get; set; }
+
         [NopResourceDisplayName("Admin.System.ScheduleTasks.Enabled")]
         public bool Enabled { get; set; }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
@@ -106,7 +106,14 @@
             </div>
             <div class="form-group row">
                 <div class="col-md-3">
-                    <label class="col-form-label">Order source</label>
+                    @* OrderSource has no [NopResourceDisplayName], so nop-label can't be
+                       used directly - but its wrapping <div class="label-wrapper"> is what
+                       right-aligns/flexes the label to match every other row here (see
+                       .form-horizontal .label-wrapper in admin/styles.css), so replicate it
+                       manually instead of a bare <label>. *@
+                    <div class="label-wrapper">
+                        <label class="col-form-label">Order source</label>
+                    </div>
                 </div>
                 <div class="col-md-9">
                     <div class="form-text-row">@Model.OrderSource</div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ScheduleTask/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ScheduleTask/List.cshtml
@@ -60,6 +60,13 @@
                                     Editable = true,
                                     EditType = EditType.Number
                                 },
+                                new ColumnProperty(nameof(ScheduleTaskModel.CronExpression))
+                                {
+                                    Title = T("Admin.System.ScheduleTasks.CronExpression").Text,
+                                    Width = "150",
+                                    Editable = true,
+                                    EditType = EditType.String
+                                },
                                 new ColumnProperty(nameof(ScheduleTaskModel.Enabled))
                                 {
                                     Title = T("Admin.System.ScheduleTasks.Enabled").Text,

--- a/src/Presentation/Nop.Web/Areas/Admin/sitemap.config
+++ b/src/Presentation/Nop.Web/Areas/Admin/sitemap.config
@@ -108,6 +108,7 @@
       <siteMapNode SystemName="Maintenance" nopResource="Admin.System.Maintenance" PermissionNames="ManageMaintenance" controller="Common" action="Maintenance"  IconClass="far fa-dot-circle"/>
       <siteMapNode SystemName="Queued emails" nopResource="Admin.System.QueuedEmails" PermissionNames="ManageMessageQueue" controller="QueuedEmail" action="List"  IconClass="far fa-dot-circle"/>
       <siteMapNode SystemName="Schedule tasks" nopResource="Admin.System.ScheduleTasks" PermissionNames="ManageScheduleTasks" controller="ScheduleTask" action="List"  IconClass="far fa-dot-circle"/>
+      <siteMapNode SystemName="Hangfire" nopResource="Admin.System.Hangfire" PermissionNames="ManageScheduleTasks" url="/hangfire" IconClass="far fa-clock" OpenUrlInNewTab="true"/>
       <siteMapNode SystemName="Search engine friendly names" nopResource="Admin.System.SeNames" PermissionNames="ManageMaintenance" controller="Common" action="SeNames"  IconClass="far fa-dot-circle"/>
       <siteMapNode SystemName="Templates" nopResource="Admin.System.Templates" PermissionNames="ManageMaintenance" controller="Template" action="List" IconClass="far fa-dot-circle"/>     
     </siteMapNode>

--- a/src/Presentation/Nop.Web/Controllers/Api/Customer/CustomerApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Customer/CustomerApiController.cs
@@ -140,6 +140,10 @@ namespace Nop.Web.Controllers.Api.Customer
                 RemindMeNotification = customer.RemindMeNotification,
                 RateReminderNotification = customer.RateReminderNotification,
                 OrderStatusNotification = customer.OrderStatusNotification,
+                //preferred order-reminder time as "HH:mm" (null when no preference -> tenant default applies)
+                RemindMeTime = customer.RemindMeTime.HasValue
+                    ? System.TimeSpan.FromMinutes(customer.RemindMeTime.Value).ToString(@"hh\:mm", System.Globalization.CultureInfo.InvariantCulture)
+                    : null,
                 avatar = await _pictureService.GetPictureUrlAsync(await _genericAttributeService.GetAttributeAsync<int>(customer, NopCustomerDefaults.AvatarPictureIdAttribute), _mediaSettings.AvatarPictureSize, true)
             });
         }

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -652,6 +652,14 @@ namespace Nop.Web.Controllers.Api.Order
                 });
             }
 
+            //InitPayment can fail/decline before ever producing a redirect URL (e.g. the
+            //bank's own error, network issue) - the order still exists (Pending, unpaid),
+            //so the client's fallback-message path needs something other than the generic
+            //"couldn't place order", which would wrongly imply nothing was created.
+            var message = string.IsNullOrEmpty(paymentResult.PaymentUrl)
+                ? "Your order was saved, but the card payment couldn't be started. Please try paying again from your Orders."
+                : null;
+
             return Ok(new
             {
                 success = false,
@@ -659,7 +667,8 @@ namespace Nop.Web.Controllers.Api.Order
                 orderId = placedOrder.Id,
                 paymentUrl = paymentResult.PaymentUrl,
                 amountDue = paymentResult.AmountDue,
-                amountCoveredByAllowance = paymentResult.AmountCoveredByAllowance
+                amountCoveredByAllowance = paymentResult.AmountCoveredByAllowance,
+                message
             });
         }
 

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -69,7 +69,8 @@ namespace Nop.Web.Controllers.Api.Order
         private readonly ICheckoutAttributeService _checkoutAttributeService;
         private readonly IGenericAttributeService _genericAttributeService;
         private readonly ICheckoutAttributeParser _checkoutAttributeParser;
-        
+        private readonly IAmeriaVPosPaymentService _ameriaVPosPaymentService;
+
         private readonly OrderSettings _orderSettings;
 
         #endregion
@@ -101,7 +102,8 @@ namespace Nop.Web.Controllers.Api.Order
             ILogger logger, 
             ICheckoutAttributeService checkoutAttributeService, 
             IGenericAttributeService genericAttributeService, 
-            ICheckoutAttributeParser checkoutAttributeParser, 
+            ICheckoutAttributeParser checkoutAttributeParser,
+            IAmeriaVPosPaymentService ameriaVPosPaymentService,
             OrderSettings orderSettings)
         {
             _orderService = orderService;
@@ -130,6 +132,7 @@ namespace Nop.Web.Controllers.Api.Order
             _checkoutAttributeService = checkoutAttributeService;
             _genericAttributeService = genericAttributeService;
             _checkoutAttributeParser = checkoutAttributeParser;
+            _ameriaVPosPaymentService = ameriaVPosPaymentService;
             _orderSettings = orderSettings;
         }
 
@@ -598,7 +601,14 @@ namespace Nop.Web.Controllers.Api.Order
             processPaymentRequest.ScheduleDate = scheduleDateUtc;
             processPaymentRequest.OrderSource = OrderSource.Mobile;
 
-            processPaymentRequest.PaymentMethodSystemName = "Payments.CheckMoneyOrder";
+            //AmeriaVPos is always the selected method; it internally decides (via
+            //IAmeriaVPosPaymentService, which mirrors Idram's existing web allowance
+            //logic) whether the order is fully covered by the company allowance
+            //(marks Paid, no card involved) or needs a card payment for the shortfall
+            //(full amount for an "Allowance Excempt" customer, partial otherwise) -
+            //replacing the old hard-coded CheckMoneyOrder, which had no way to collect
+            //a card payment and simply failed the order over-allowance.
+            processPaymentRequest.PaymentMethodSystemName = "Payments.AmeriaVPos";
             var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
 
             if (!placeOrderResult.Success)
@@ -624,11 +634,58 @@ namespace Nop.Web.Controllers.Api.Order
                 });
             }
 
+            var placedOrder = placeOrderResult.PlacedOrder;
+
+            //ProcessPaymentAsync (called synchronously inside PlaceOrderAsync above) is a
+            //no-op for AmeriaVPos - the order needs to exist first. This is the mobile/API
+            //equivalent of the web IPaymentMethod.PostProcessPaymentAsync redirect step,
+            //calling the same shared service directly instead of writing an HTTP redirect.
+            var paymentResult = await _ameriaVPosPaymentService.InitiateOrCompletePaymentAsync(placedOrder, "Mobile");
+
+            if (!paymentResult.RequiresPayment)
+            {
+                return Ok(new
+                {
+                    success = true,
+                    message = await _localizationService.GetResourceAsync("Order.Placed.Successfully"),
+                    orderId = placedOrder.Id
+                });
+            }
+
+            return Ok(new
+            {
+                success = false,
+                requiresPayment = true,
+                orderId = placedOrder.Id,
+                paymentUrl = paymentResult.PaymentUrl,
+                amountDue = paymentResult.AmountDue,
+                amountCoveredByAllowance = paymentResult.AmountCoveredByAllowance
+            });
+        }
+
+        /// <summary>
+        /// Lightweight status check for the AmeriaVPos self-pay flow's deep-link return
+        /// screen. Reads the payment-attempt ledger only - it does not re-call
+        /// GetPaymentDetails on every poll (BackUrlReturn/the reconciliation task already
+        /// resolve the authoritative status server-side).
+        /// </summary>
+        [HttpGet("{orderId}/payment-status")]
+        public async Task<IActionResult> GetPaymentStatus(int orderId)
+        {
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var order = await _orderService.GetOrderByIdAsync(orderId);
+
+            if (order == null || order.CustomerId != customer.Id || order.Deleted)
+                return Ok(new { success = false });
+
+            var result = await _ameriaVPosPaymentService.GetLatestAttemptStatusAsync(order);
+
             return Ok(new
             {
                 success = true,
-                message = await _localizationService.GetResourceAsync("Order.Placed.Successfully"),
-                orderId = placeOrderResult.PlacedOrder.Id
+                status = result.Status,
+                resolved = result.Resolved,
+                amountDue = result.AmountDue
             });
         }
 

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -70,6 +70,7 @@ namespace Nop.Web.Controllers.Api.Order
         private readonly IGenericAttributeService _genericAttributeService;
         private readonly ICheckoutAttributeParser _checkoutAttributeParser;
         private readonly IAmeriaVPosPaymentService _ameriaVPosPaymentService;
+        private readonly IPaymentPluginManager _paymentPluginManager;
 
         private readonly OrderSettings _orderSettings;
 
@@ -104,6 +105,7 @@ namespace Nop.Web.Controllers.Api.Order
             IGenericAttributeService genericAttributeService, 
             ICheckoutAttributeParser checkoutAttributeParser,
             IAmeriaVPosPaymentService ameriaVPosPaymentService,
+            IPaymentPluginManager paymentPluginManager,
             OrderSettings orderSettings)
         {
             _orderService = orderService;
@@ -133,6 +135,7 @@ namespace Nop.Web.Controllers.Api.Order
             _genericAttributeService = genericAttributeService;
             _checkoutAttributeParser = checkoutAttributeParser;
             _ameriaVPosPaymentService = ameriaVPosPaymentService;
+            _paymentPluginManager = paymentPluginManager;
             _orderSettings = orderSettings;
         }
 
@@ -601,14 +604,25 @@ namespace Nop.Web.Controllers.Api.Order
             processPaymentRequest.ScheduleDate = scheduleDateUtc;
             processPaymentRequest.OrderSource = OrderSource.Mobile;
 
-            //AmeriaVPos is always the selected method; it internally decides (via
-            //IAmeriaVPosPaymentService, which mirrors Idram's existing web allowance
-            //logic) whether the order is fully covered by the company allowance
-            //(marks Paid, no card involved) or needs a card payment for the shortfall
-            //(full amount for an "Allowance Excempt" customer, partial otherwise) -
-            //replacing the old hard-coded CheckMoneyOrder, which had no way to collect
-            //a card payment and simply failed the order over-allowance.
-            processPaymentRequest.PaymentMethodSystemName = "Payments.AmeriaVPos";
+            //AmeriaVPos is the selected method whenever it's active; it internally
+            //decides (via IAmeriaVPosPaymentService, which mirrors Idram's existing web
+            //allowance logic) whether the order is fully covered by the company
+            //allowance (marks Paid, no card involved) or needs a card payment for the
+            //shortfall (full amount for an "Allowance Excempt" customer, partial
+            //otherwise) - replacing the old hard-coded CheckMoneyOrder, which had no way
+            //to collect a card payment and simply failed the order over-allowance.
+            //
+            //If AmeriaVPos is disabled admin-side (e.g. an AmeriaBank outage), fall back
+            //to CheckMoneyOrder (allowance-only) instead of hard-coding AmeriaVPos and
+            //letting PlaceOrderAsync fail with a confusing "payment method is not
+            //active" - this degrades mobile checkout back to its pre-AmeriaVPos
+            //behavior (allowance-covered orders still succeed; over-allowance orders
+            //fail with CheckMoneyOrderPaymentProcessor's own clear "remaining allowance
+            //not enough" error) rather than breaking checkout entirely.
+            var isAmeriaVPosActive = await _paymentPluginManager.IsPluginActiveAsync("Payments.AmeriaVPos", customer, store.Id);
+            processPaymentRequest.PaymentMethodSystemName = isAmeriaVPosActive
+                ? "Payments.AmeriaVPos"
+                : "Payments.CheckMoneyOrder";
             var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
 
             if (!placeOrderResult.Success)
@@ -635,6 +649,19 @@ namespace Nop.Web.Controllers.Api.Order
             }
 
             var placedOrder = placeOrderResult.PlacedOrder;
+
+            if (!isAmeriaVPosActive)
+            {
+                //CheckMoneyOrder resolves synchronously inside PlaceOrderAsync above
+                //(marks Paid, or PlaceOrderAsync fails via the branch above) - there's no
+                //AmeriaVPos-style post-processing/redirect step to run.
+                return Ok(new
+                {
+                    success = true,
+                    message = await _localizationService.GetResourceAsync("Order.Placed.Successfully"),
+                    orderId = placedOrder.Id
+                });
+            }
 
             //ProcessPaymentAsync (called synchronously inside PlaceOrderAsync above) is a
             //no-op for AmeriaVPos - the order needs to exist first. This is the mobile/API

--- a/src/Presentation/Nop.Web/Controllers/Api/PushNotification/PushNotificationApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/PushNotification/PushNotificationApiController.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
 using Nop.Services.Customers;
@@ -40,6 +42,38 @@ namespace Nop.Web.Controllers.Api.PushNotification
             public bool OrderStatusNotification { get; set; }
             public bool RemindMeNotification { get; set; }
             public bool RateReminderNotification { get; set; }
+
+            /// <summary>
+            /// Preferred order-reminder time as "HH:mm" (24-hour, snapped to 15-minute slots). Null/empty
+            /// clears the preference so the tenant default applies.
+            /// </summary>
+            public string RemindMeTime { get; set; }
+        }
+
+        /// <summary>
+        /// 15-minute reminder slot granularity (matches the mobile picker and the dispatcher CRON).
+        /// </summary>
+        private const int SLOT_MINUTES = 15;
+
+        /// <summary>
+        /// Parses an "HH:mm" reminder time into minutes-after-midnight, snapped to a 15-minute slot.
+        /// Returns null for null/empty/invalid input (meaning "no preference").
+        /// </summary>
+        private static int? ParseRemindMeTime(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
+            if (!TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var timeOfDay))
+                return null;
+
+            var minutes = (int)timeOfDay.TotalMinutes;
+            if (minutes < 0)
+                minutes = 0;
+            if (minutes > 1439)
+                minutes = 1439;
+
+            return minutes / SLOT_MINUTES * SLOT_MINUTES;
         }
 
         #endregion
@@ -56,6 +90,7 @@ namespace Nop.Web.Controllers.Api.PushNotification
             customer.OrderStatusNotification = model.OrderStatusNotification;
             customer.RateReminderNotification = model.RateReminderNotification;
             customer.RemindMeNotification= model.RemindMeNotification;
+            customer.RemindMeTime = ParseRemindMeTime(model.RemindMeTime);
             await _customerService.UpdateCustomerAsync(customer);
 
             return Ok(new { success = true, message = await _localizationService.GetResourceAsync("Customer.Notification.Settings.Updated") });

--- a/src/Presentation/Nop.Web/Infrastructure/HangfireDashboardAuthorizationFilter.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/HangfireDashboardAuthorizationFilter.cs
@@ -1,0 +1,27 @@
+using Hangfire.Dashboard;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Services.Security;
+
+namespace Nop.Web.Infrastructure
+{
+    /// <summary>
+    /// Restricts the Hangfire dashboard (/hangfire) to admins holding the <see cref="StandardPermissionProvider.ManageScheduleTasks"/>
+    /// permission - the same gate as the admin "Schedule tasks" page. This guards the route itself; the admin
+    /// menu link is independently rendered only for authorized users (see Areas/Admin/sitemap.config).
+    /// </summary>
+    public partial class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+    {
+        public bool Authorize(DashboardContext context)
+        {
+            var httpContext = context.GetHttpContext();
+
+            //resolve from the request scope so the current (cookie-authenticated) admin is used
+            var permissionService = httpContext?.RequestServices?.GetService<IPermissionService>();
+            if (permissionService == null)
+                return false;
+
+            return permissionService.AuthorizeAsync(StandardPermissionProvider.ManageScheduleTasks)
+                .GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Presentation/Nop.Web/Infrastructure/HangfireRecurringTaskRegistrar.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/HangfireRecurringTaskRegistrar.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Hangfire;
+using Nop.Services.Tasks;
+
+namespace Nop.Web.Infrastructure
+{
+    /// <summary>
+    /// Reconciles Hangfire recurring jobs against the ScheduleTask table: every enabled task that carries a
+    /// CronExpression is (re)registered as a recurring job keyed by its Type; anything else is removed. Invoked
+    /// from StartEngine after migrations have run (see IRecurringTaskRegistrar), so the CronExpression column is
+    /// guaranteed to exist. The admin ScheduleTask controller performs the same reconcile on edit, so CRON
+    /// changes take effect at runtime without an app restart.
+    /// </summary>
+    public partial class HangfireRecurringTaskRegistrar : IRecurringTaskRegistrar
+    {
+        private readonly IRecurringJobManager _recurringJobManager;
+        private readonly IScheduleTaskService _scheduleTaskService;
+
+        public HangfireRecurringTaskRegistrar(IRecurringJobManager recurringJobManager,
+            IScheduleTaskService scheduleTaskService)
+        {
+            _recurringJobManager = recurringJobManager;
+            _scheduleTaskService = scheduleTaskService;
+        }
+
+        public async System.Threading.Tasks.Task RegisterAsync()
+        {
+            var tasks = await _scheduleTaskService.GetAllTasksAsync(true);
+
+            foreach (var task in tasks)
+            {
+                //recurring-job id == task type (stable, one row = one type)
+                var recurringJobId = task.Type;
+                var taskType = task.Type;
+
+                if (task.Enabled && !string.IsNullOrWhiteSpace(task.CronExpression))
+                    _recurringJobManager.AddOrUpdate<HangfireScheduleTaskRunner>(recurringJobId,
+                        runner => runner.RunScheduleTaskAsync(taskType), task.CronExpression);
+                else
+                    _recurringJobManager.RemoveIfExists(recurringJobId);
+            }
+        }
+    }
+}

--- a/src/Presentation/Nop.Web/Infrastructure/HangfireScheduleTaskRunner.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/HangfireScheduleTaskRunner.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Services.Tasks;
+using ILogger = Nop.Services.Logging.ILogger;
+
+namespace Nop.Web.Infrastructure
+{
+    /// <summary>
+    /// Executes a nopCommerce <see cref="IScheduleTask"/> in-process when triggered by a Hangfire recurring job.
+    /// No HTTP self-POST (unlike the legacy <c>TaskThread</c>): Hangfire.Autofac opens a fresh Autofac lifetime
+    /// scope per job, and the task instance (plus its dependencies) is resolved from THIS runner's injected
+    /// <see cref="IServiceProvider"/> - i.e. that per-job scope - so scoped services (DB connection, etc.) are
+    /// isolated per run. Timestamps mirror the legacy <c>Task.ExecuteTask</c> bookkeeping; failures propagate so
+    /// Hangfire records/retries them and they show on the dashboard. See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    public partial class HangfireScheduleTaskRunner
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IScheduleTaskService _scheduleTaskService;
+        private readonly ILogger _logger;
+
+        public HangfireScheduleTaskRunner(IServiceProvider serviceProvider,
+            IScheduleTaskService scheduleTaskService,
+            ILogger logger)
+        {
+            _serviceProvider = serviceProvider;
+            _scheduleTaskService = scheduleTaskService;
+            _logger = logger;
+        }
+
+        // Prevent a slow run from overlapping the next CRON tick for the same task (per task type + args).
+        [DisableConcurrentExecution(timeoutInSeconds: 60)]
+        // Do NOT retry-storm a failing recurring task: fail once (visible on the dashboard) and let the next
+        // CRON tick try again - matching the legacy timer's "log and move on" behavior. Without this, Hangfire's
+        // default 10-attempt retry piles up Scheduled retries for any task that fails every run.
+        [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
+        public async System.Threading.Tasks.Task RunScheduleTaskAsync(string taskType)
+        {
+            if (string.IsNullOrWhiteSpace(taskType))
+                return;
+
+            var scheduleTask = await _scheduleTaskService.GetTaskByTypeAsync(taskType);
+            if (scheduleTask == null || !scheduleTask.Enabled)
+                return;
+
+            //resolve the IScheduleTask CLR type (allow a bare type name, like the legacy runner)
+            var type = Type.GetType(scheduleTask.Type) ??
+                       AppDomain.CurrentDomain.GetAssemblies()
+                           .Select(a => a.GetType(scheduleTask.Type))
+                           .FirstOrDefault(t => t != null);
+            if (type == null)
+            {
+                //unresolvable type (e.g. a task registered in the DB whose class was removed/never shipped).
+                //Log and no-op rather than throwing, so Hangfire does not retry-storm this recurring job.
+                await _logger.WarningAsync($"Schedule task type '{scheduleTask.Type}' could not be resolved; skipping run.");
+                return;
+            }
+
+            //resolve the task within the per-job Autofac scope (so its scoped deps are isolated per run)
+            var instance = (_serviceProvider.GetService(type)
+                            ?? ActivatorUtilities.CreateInstance(_serviceProvider, type)) as IScheduleTask;
+            if (instance == null)
+                return;
+
+            scheduleTask.LastStartUtc = DateTime.UtcNow;
+            await _scheduleTaskService.UpdateTaskAsync(scheduleTask);
+
+            try
+            {
+                await instance.ExecuteAsync();
+
+                scheduleTask.LastEndUtc = scheduleTask.LastSuccessUtc = DateTime.UtcNow;
+                await _scheduleTaskService.UpdateTaskAsync(scheduleTask);
+            }
+            catch (Exception exc)
+            {
+                scheduleTask.LastEndUtc = DateTime.UtcNow;
+                //disable the task on error only if it is configured to stop on error (mirrors legacy behavior)
+                scheduleTask.Enabled = !scheduleTask.StopOnError;
+                await _scheduleTaskService.UpdateTaskAsync(scheduleTask);
+
+                await _logger.ErrorAsync($"Error while running the '{scheduleTask.Name}' schedule task ({taskType})", exc);
+
+                //rethrow so Hangfire records the failure (dashboard) and applies its retry policy
+                throw;
+            }
+        }
+    }
+}

--- a/src/Presentation/Nop.Web/Infrastructure/HangfireStartup.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/HangfireStartup.cs
@@ -1,0 +1,99 @@
+using Autofac.Extensions.DependencyInjection;
+using Hangfire;
+using Hangfire.PostgreSql;
+using Hangfire.SqlServer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure;
+using Nop.Data;
+using Nop.Services.Tasks;
+
+namespace Nop.Web.Infrastructure
+{
+    /// <summary>
+    /// Configures Hangfire as the dynamic / cron-capable scheduling engine. It coexists with the legacy
+    /// timer-based ScheduleTask engine (TaskManager): tasks that carry a CronExpression are owned by
+    /// Hangfire, the rest keep running on the legacy interval timer.
+    /// Job storage is the tenant's OWN database, chosen at runtime from dataSettings.json, so every tenant
+    /// container gets an isolated Hangfire schema. See docs/plans/2026-07-22-dynamic-scheduled-tasks.md.
+    /// </summary>
+    public partial class HangfireStartup : INopStartup
+    {
+        /// <summary>
+        /// Whether the current data provider has a supported Hangfire storage.
+        /// </summary>
+        private static bool IsSupportedProvider(DataSettings dataSettings)
+        {
+            return dataSettings?.DataProvider is DataProviderType.SqlServer or DataProviderType.PostgreSQL;
+        }
+
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            //nothing to store jobs in until the app is installed
+            if (!DataSettingsManager.IsDatabaseInstalled())
+                return;
+
+            var dataSettings = DataSettingsManager.LoadSettings();
+            if (!IsSupportedProvider(dataSettings))
+                return;
+
+            services.AddHangfire(config =>
+            {
+                config
+                    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+                    .UseSimpleAssemblyNameTypeSerializer()
+                    .UseRecommendedSerializerSettings();
+
+                switch (dataSettings.DataProvider)
+                {
+                    case DataProviderType.SqlServer:
+                        config.UseSqlServerStorage(dataSettings.ConnectionString);
+                        break;
+                    case DataProviderType.PostgreSQL:
+                        config.UsePostgreSqlStorage(dataSettings.ConnectionString);
+                        break;
+                }
+            });
+
+            //the background server (IHostedService) that actually processes recurring/enqueued jobs
+            services.AddHangfireServer();
+
+            //in-process executor for CRON-triggered schedule tasks (resolved per-job by Hangfire.Autofac)
+            services.AddScoped<HangfireScheduleTaskRunner>();
+
+            //registers CRON-driven schedule tasks as recurring jobs; invoked from StartEngine after migrations
+            services.AddScoped<IRecurringTaskRegistrar, HangfireRecurringTaskRegistrar>();
+        }
+
+        public void Configure(IApplicationBuilder application)
+        {
+            if (!DataSettingsManager.IsDatabaseInstalled())
+                return;
+
+            if (!IsSupportedProvider(DataSettingsManager.LoadSettings()))
+                return;
+
+            //resolve jobs (and their scoped nop dependencies) through the Autofac container;
+            //the activator opens a child lifetime scope per job execution
+            GlobalConfiguration.Configuration.UseAutofacActivator(application.ApplicationServices.GetAutofacRoot());
+
+            //dashboard, gated by the same permission as the admin Schedule Tasks page
+            application.UseHangfireDashboard("/hangfire", new DashboardOptions
+            {
+                Authorization = new[] { new HangfireDashboardAuthorizationFilter() },
+                DisplayStorageConnectionString = false
+            });
+
+            //NOTE: recurring jobs are NOT registered here - Configure() runs before nopCommerce applies its
+            //FluentMigrator migrations (StartEngine), so the CronExpression column may not exist yet. Registration
+            //happens via HangfireRecurringTaskRegistrar (IRecurringTaskRegistrar), invoked from StartEngine after
+            //migrations.
+        }
+
+        /// <summary>
+        /// After Authorization middleware (600) and before the MVC endpoints (1000).
+        /// </summary>
+        public int Order => 700;
+    }
+}

--- a/src/Presentation/Nop.Web/Nop.Web.csproj
+++ b/src/Presentation/Nop.Web/Nop.Web.csproj
@@ -64,6 +64,9 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.1" />
     <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.9" />
+    <!-- Hangfire dynamic/cron scheduler (see docs/plans/2026-07-22-dynamic-scheduled-tasks.md). -->
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
+    <PackageReference Include="Hangfire.Autofac" Version="2.6.0" />
   </ItemGroup>
   <!-- This target execute after "Build" target.
     We use it to clean up folder with plugins from unnecessary and obsolete libraries. -->


### PR DESCRIPTION
Promotes the `hotfix/ameriabank-vpos-self-pay` branch to `master`. Merged as a single merge commit so the whole set can be rolled back at once (`git revert -m 1 <merge-sha>`).

## What's included
**AmeriaBank vPOS self-pay** (16 commits) — card checkout for no-benefit / over-allowance customers: InitPayment→redirect→GetPaymentDetails flow, refund/cancel order actions, reconciliation task, AmeriaVPos plugin + Docker build, plus fixes (decline handling, BackURL/OrderID collisions, refund modal). ⚠️ Still validated against the AmeriaBank **sandbox**.

**Company allowance / delivery fixes** — balance now computed against the *selected delivery date* (not "today"); delivery schedule no longer shows zero slots after today's cutoff; Order-ahead-days field on the Company edit page.

**Hangfire dynamic (cron) scheduled tasks + per-user order reminders** — schedule tasks can run on a CRON expression (`ScheduleTask.CronExpression`) via Hangfire alongside the legacy timer; tasks execute in-process (no HTTP self-POST), one dispatcher, no double-fire; `/hangfire` dashboard gated by `ManageScheduleTasks`; per-customer daily reminder time in 15-min slots (`Customer.RemindMeTime`) with the reminder task bucketing by the customer's time zone. Migrations convert clock-aligned intervals to cron; non-aligned stay on the timer.

## Verification (dev)
Clean boot, all migrations applied, dashboard gated, reminder API round-trip, cron tasks registered as recurring jobs, and a 15-minute soak confirming single-engine execution, no double-fire, and zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)