### PR TITLE
Commit remaining AmeriaVPos self-pay working-tree changes

### DIFF
--- a/src/Libraries/Nop.Services/Payments/ICompanyAllowancePaymentMethod.cs
+++ b/src/Libraries/Nop.Services/Payments/ICompanyAllowancePaymentMethod.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nop.Core.Domain.Companies;
 using Nop.Core.Domain.Customers;
+using Nop.Core.Domain.Orders;
 
 namespace Nop.Services.Payments
 {
@@ -9,5 +11,14 @@ namespace Nop.Services.Payments
     {
         public Task<CustomerBalanceResult> GetCustomerRemainingAllowance(CustomerBalanceRequest customerBalanceRequest);
         public Task<bool> VoidAllowance(DateTime date, Customer customer = null);
+
+        /// <summary>
+        /// Whether this method would hide itself from the checkout payment-method list for
+        /// the given cart (insufficient/no allowance, shippable-product setting, etc). Reused
+        /// by AmeriaVPosPaymentProcessor.HidePaymentMethodAsync so the two payment methods stay
+        /// mutually exclusive - an order is never split between allowance and card, so exactly
+        /// one of the two should ever be a selectable radio button.
+        /// </summary>
+        public Task<bool> HidePaymentMethodAsync(IList<ShoppingCartItem> cart);
     }
 }

--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -47,6 +47,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nop.Plugin.Payments.Idram",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nop.Plugin.Company.Company", "Plugins\Nop.Plugin.Company.Company\Nop.Plugin.Company.Company.csproj", "{CD87DF94-37B8-4F7B-8897-783DF922873E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Payments.AmeriaVPos", "Plugins\Nop.Plugin.Payments.AmeriaVPos\Nop.Plugin.Payments.AmeriaVPos.csproj", "{22C12000-1022-4E51-BD2A-49820C1C5ACA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -257,6 +259,18 @@ Global
 		{CD87DF94-37B8-4F7B-8897-783DF922873E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{CD87DF94-37B8-4F7B-8897-783DF922873E}.Release|x86.ActiveCfg = Release|Any CPU
 		{CD87DF94-37B8-4F7B-8897-783DF922873E}.Release|x86.Build.0 = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Debug|x86.Build.0 = Debug|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|x86.ActiveCfg = Release|Any CPU
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -280,6 +294,7 @@ Global
 		{F358E6C4-73FF-41C3-BF53-E350F3733258} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{1CCF5C06-72E9-4226-93A7-C2CC6A64C8B3} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{CD87DF94-37B8-4F7B-8897-783DF922873E} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
+		{22C12000-1022-4E51-BD2A-49820C1C5ACA} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE72A8B2-332A-4175-9319-6726D36E9D25}

--- a/src/Plugins/Nop.Plugin.Company.Company/Factories/CheckoutModelFactory_Overriden.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Factories/CheckoutModelFactory_Overriden.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nop.Core;
+using Nop.Core.Domain.Common;
+using Nop.Core.Domain.Customers;
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Payments;
+using Nop.Core.Domain.Shipping;
+using Nop.Plugin.Company.Company.Services;
+using Nop.Services.Catalog;
+using Nop.Services.Common;
+using Nop.Services.Companies;
+using Nop.Services.Customers;
+using Nop.Services.Directory;
+using Nop.Services.Helpers;
+using Nop.Services.Localization;
+using Nop.Services.Orders;
+using Nop.Services.Payments;
+using Nop.Services.Shipping;
+using Nop.Services.Shipping.Pickup;
+using Nop.Services.Stores;
+using Nop.Services.Tax;
+using Nop.Web.Factories;
+using Nop.Web.Models.Checkout;
+using TimeZoneConverter;
+
+namespace Nop.Plugin.Company.Company.Factories;
+
+/// <summary>
+/// Adds an AmeriaVPos self-pay warning to the storefront OPC confirm-order step,
+/// mirroring the mobile app's Confirm-order sheet banner ("Order exceeds allowance,
+/// you will be redirected for payment"). The core CheckoutModelFactory has no notion
+/// of company allowance, so this appends the check rather than duplicating the whole
+/// method.
+/// </summary>
+public class CheckoutModelFactory_Overriden : CheckoutModelFactory
+{
+    private readonly IWorkContext _workContext;
+    private readonly IStoreContext _storeContext;
+    private readonly IOrderTotalCalculationService _orderTotalCalculationService;
+    private readonly ICompanyAllowancePaymentMethod _companyAllowancePaymentMethod;
+    private readonly IDeliveryTimeStorageService _deliveryTimeStorageService;
+    private readonly ICompanyService _companyService;
+    private readonly IDateTimeHelper _dateTimeHelper;
+    private readonly ILocalizationService _localizationService;
+    private readonly IPaymentPluginManager _paymentPluginManager;
+
+    public CheckoutModelFactory_Overriden(
+        IWorkContext workContext,
+        IStoreContext storeContext,
+        IOrderTotalCalculationService orderTotalCalculationService,
+        ICompanyAllowancePaymentMethod companyAllowancePaymentMethod,
+        IDeliveryTimeStorageService deliveryTimeStorageService,
+        ICompanyService companyService,
+        IDateTimeHelper dateTimeHelper,
+        ILocalizationService localizationService,
+        IPaymentPluginManager paymentPluginManager,
+        AddressSettings addressSettings,
+        CommonSettings commonSettings,
+        IAddressModelFactory addressModelFactory,
+        IAddressService addressService,
+        ICountryService countryService,
+        ICurrencyService currencyService,
+        ICustomerService customerService,
+        IGenericAttributeService genericAttributeService,
+        IOrderProcessingService orderProcessingService,
+        IPaymentService paymentService,
+        IPickupPluginManager pickupPluginManager,
+        IPriceFormatter priceFormatter,
+        IRewardPointService rewardPointService,
+        IShippingPluginManager shippingPluginManager,
+        IShippingService shippingService,
+        IShoppingCartService shoppingCartService,
+        IStateProvinceService stateProvinceService,
+        IStoreMappingService storeMappingService,
+        ITaxService taxService,
+        OrderSettings orderSettings,
+        PaymentSettings paymentSettings,
+        RewardPointsSettings rewardPointsSettings,
+        ShippingSettings shippingSettings)
+        : base(addressSettings,
+            commonSettings,
+            addressModelFactory,
+            addressService,
+            countryService,
+            currencyService,
+            customerService,
+            genericAttributeService,
+            localizationService,
+            orderProcessingService,
+            orderTotalCalculationService,
+            paymentPluginManager,
+            paymentService,
+            pickupPluginManager,
+            priceFormatter,
+            rewardPointService,
+            shippingPluginManager,
+            shippingService,
+            shoppingCartService,
+            stateProvinceService,
+            storeContext,
+            storeMappingService,
+            taxService,
+            workContext,
+            orderSettings,
+            paymentSettings,
+            rewardPointsSettings,
+            shippingSettings,
+            dateTimeHelper,
+            companyService)
+    {
+        _workContext = workContext;
+        _storeContext = storeContext;
+        _orderTotalCalculationService = orderTotalCalculationService;
+        _companyAllowancePaymentMethod = companyAllowancePaymentMethod;
+        _deliveryTimeStorageService = deliveryTimeStorageService;
+        _companyService = companyService;
+        _dateTimeHelper = dateTimeHelper;
+        _localizationService = localizationService;
+        _paymentPluginManager = paymentPluginManager;
+    }
+
+    public override async Task<CheckoutConfirmModel> PrepareConfirmOrderModelAsync(IList<ShoppingCartItem> cart)
+    {
+        var model = await base.PrepareConfirmOrderModelAsync(cart);
+
+        var customer = await _workContext.GetCurrentCustomerAsync();
+        var store = await _storeContext.GetCurrentStoreAsync();
+
+        // Only relevant if AmeriaVPos is actually the active/selectable payment method -
+        // a customer on a different payment method never gets redirected for card payment.
+        var isAmeriaVPosActive = await _paymentPluginManager.IsPluginActiveAsync("Payments.AmeriaVPos", customer, store.Id);
+        if (!isAmeriaVPosActive)
+            return model;
+
+        var cartTotals = await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart);
+        if (cartTotals.shoppingCartTotal is not decimal total || total <= 0)
+            return model;
+
+        // Use the customer's actual selected delivery date (converted to the company's
+        // timezone/UTC), same as CheckoutController_Overriden.OpcConfirmOrder - not
+        // DateTime.UtcNow, which the payment-method-step description uses only as a
+        // preview approximation before a delivery time is even picked.
+        var deliveryTime = await _deliveryTimeStorageService.GetSelectedDeliveryTimeAsync(customer, store.Id);
+        DateTime orderDateUtc;
+        if (deliveryTime.HasValue)
+        {
+            var company = await _companyService.GetCompanyByCustomerIdAsync(customer.Id);
+            var timeZoneInfo = company == null
+                ? await _dateTimeHelper.GetCustomerTimeZoneAsync(customer)
+                : TZConvert.GetTimeZoneInfo(company.TimeZone);
+            orderDateUtc = _dateTimeHelper.ConvertToUtcTime(deliveryTime.Value, timeZoneInfo);
+        }
+        else
+        {
+            orderDateUtc = DateTime.UtcNow;
+        }
+
+        var balance = await _companyAllowancePaymentMethod.GetCustomerRemainingAllowance(
+            new CustomerBalanceRequest { Customer = customer, OrderDateUtc = orderDateUtc });
+
+        // Never split a single order between allowance and card - see the comment on
+        // IAmeriaVPosPaymentService.InitiateOrCompletePaymentAsync for why.
+        var remainingAllowance = balance?.RemainingAllowance ?? 0M;
+        if (remainingAllowance >= total)
+            return model;
+
+        model.AllowanceExceededWarning =
+            await _localizationService.GetResourceAsync("Plugins.Payments.AmeriaVPos.Description.FullSelfPay");
+
+        return model;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Company.Company/Infrastructure/DependencyRegistrar.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Infrastructure/DependencyRegistrar.cs
@@ -4,6 +4,7 @@ using Nop.Core.Infrastructure;
 using Nop.Core.Infrastructure.DependencyManagement;
 using Nop.Plugin.Company.Company.Areas.Admin.Factories;
 using Nop.Plugin.Company.Company.Controllers;
+using Nop.Plugin.Company.Company.Factories;
 using Nop.Plugin.Company.Company.Services;
 
 namespace Nop.Plugin.Company.Company.Infrastructure
@@ -27,11 +28,18 @@ namespace Nop.Plugin.Company.Company.Infrastructure
             services.AddScoped<IDeliveryTimeStorageService, DeliveryTimeStorageService>();
             services.AddScoped<IGlobalDeliveryTimeValidationService, GlobalDeliveryTimeValidationService>();
             services.AddScoped<Nop.Web.Controllers.CheckoutController, CheckoutController_Overriden>();
+            services.AddScoped<Nop.Web.Factories.ICheckoutModelFactory, CheckoutModelFactory_Overriden>();
         }
 
         /// <summary>
-        /// Gets order of this dependency registrar implementation
+        /// Gets order of this dependency registrar implementation. Must run AFTER
+        /// Nop.Web's core registrar (Order = 2, registers ICheckoutModelFactory ->
+        /// CheckoutModelFactory) - dependency registrars run in ascending Order, and
+        /// the last AddScoped registration for a given interface wins. At Order = 1
+        /// this registrar's ICheckoutModelFactory -> CheckoutModelFactory_Overriden
+        /// registration ran first and was silently overwritten by the core one, so
+        /// the override never actually executed despite compiling and looking correct.
         /// </summary>
-        public int Order => 1;
+        public int Order => 3;
     }
 }

--- a/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmeriaVPos/AmeriaVPosPaymentProcessor.cs
@@ -205,12 +205,13 @@ namespace Nop.Plugin.Payments.AmeriaVPos
 
         public string GetPublicViewComponentName() => string.Empty;
 
-        public Task<bool> HidePaymentMethodAsync(IList<ShoppingCartItem> cart)
+        public async Task<bool> HidePaymentMethodAsync(IList<ShoppingCartItem> cart)
         {
-            //always visible - unlike Idram, this method handles the fully-covered case
-            //internally (marks Paid, charges nothing), so there's no "would charge zero
-            //unnecessarily" case to hide for
-            return Task.FromResult(false);
+            //mutually exclusive with the company-allowance method (CheckMoneyOrder) - an order
+            //is never split between allowance and card, so exactly one of the two should ever
+            //be a selectable radio button. Whichever one the allowance method would show, this
+            //one hides, and vice versa.
+            return !await _companyAllowancePaymentMethod.HidePaymentMethodAsync(cart);
         }
 
         public Task<ProcessPaymentResult> ProcessRecurringPaymentAsync(ProcessPaymentRequest processPaymentRequest)

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -725,6 +725,58 @@ namespace Nop.Web.Controllers.Api.Order
             });
         }
 
+        /// <summary>
+        /// Re-triggers AmeriaVPos payment for an existing Pending order - the mobile
+        /// Orders list's "Pay" button, for a self-pay order left unpaid (InitPayment
+        /// failed, or the customer backed out of the hosted pay page before checkout's
+        /// order-confirmation call ever returned a usable paymentUrl). Reuses the same
+        /// InitiateOrCompletePaymentAsync as checkout - it re-checks the customer's
+        /// current allowance too, so if it's freed up since the order was placed this can
+        /// resolve it as Paid outright instead of opening a new card payment.
+        /// </summary>
+        [HttpPost("{orderId}/initiate-payment")]
+        public async Task<IActionResult> InitiatePaymentAsync(int orderId)
+        {
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var order = await _orderService.GetOrderByIdAsync(orderId);
+
+            if (order == null || order.Deleted || order.CustomerId != customer.Id)
+            {
+                return Ok(new
+                {
+                    success = false, message = await _localizationService.GetResourceAsync("Order.NoOrderFound")
+                });
+            }
+
+            if (order.PaymentStatus == Core.Domain.Payments.PaymentStatus.Paid)
+            {
+                return Ok(new { success = true, requiresPayment = false, orderId = order.Id });
+            }
+
+            var paymentResult = await _ameriaVPosPaymentService.InitiateOrCompletePaymentAsync(order, "Mobile");
+
+            if (!paymentResult.RequiresPayment)
+            {
+                return Ok(new { success = true, requiresPayment = false, orderId = order.Id });
+            }
+
+            //Mirrors order-confirmation's own fallback message for the same failure mode
+            //(InitPayment declined/errored before producing a redirect URL).
+            var message = string.IsNullOrEmpty(paymentResult.PaymentUrl)
+                ? "The card payment couldn't be started. Please try again."
+                : null;
+
+            return Ok(new
+            {
+                success = false,
+                requiresPayment = true,
+                orderId = order.Id,
+                paymentUrl = paymentResult.PaymentUrl,
+                amountDue = paymentResult.AmountDue,
+                message
+            });
+        }
+
         [HttpPost("reorder/{orderId}")]
         public virtual async Task<IActionResult> ReOrderAsync(int orderId)
         {
@@ -1244,6 +1296,13 @@ namespace Nop.Web.Controllers.Api.Order
                 RatingText = order.RatingText,
                 DeliveryAddress = await FormatDeliveryAddressAsync(order)
             };
+
+            //Self-pay orders are never split between allowance and card (see
+            //IAmeriaVPosPaymentService.InitiateOrCompletePaymentAsync), so a Pending
+            //AmeriaVPos order always owes its full total.
+            orderModel.RequiresPayment = order.PaymentStatus == Core.Domain.Payments.PaymentStatus.Pending
+                && order.PaymentMethodSystemName == "Payments.AmeriaVPos";
+            orderModel.AmountDue = orderModel.RequiresPayment ? order.OrderTotal : 0M;
             var orderTotalInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderTotal, order.CurrencyRate);
             orderModel.OrderTotal = await _priceFormatter.FormatPriceAsync(orderTotalInCustomerCurrency, true, order.CustomerCurrencyCode, false, languageId);
 

--- a/src/Presentation/Nop.Web/Models/Checkout/CheckoutConfirmModel.cs
+++ b/src/Presentation/Nop.Web/Models/Checkout/CheckoutConfirmModel.cs
@@ -13,6 +13,13 @@ namespace Nop.Web.Models.Checkout
         public bool TermsOfServiceOnOrderConfirmPage { get; set; }
         public bool TermsOfServicePopup { get; set; }
         public string MinOrderTotalWarning { get; set; }
+        /// <summary>
+        /// Set when the cart total exceeds the customer's remaining company allowance -
+        /// confirming will redirect them to AmeriaVPos to pay the full order by card (see
+        /// Nop.Plugin.Company.Company's CheckoutModelFactory_Overriden). Mirrors the
+        /// mobile app's Confirm-order sheet warning.
+        /// </summary>
+        public string AllowanceExceededWarning { get; set; }
 
         public IList<string> Warnings { get; set; }
     }

--- a/src/Presentation/Nop.Web/Models/Order/CustomerOrderListModel.cs
+++ b/src/Presentation/Nop.Web/Models/Order/CustomerOrderListModel.cs
@@ -40,6 +40,19 @@ namespace Nop.Web.Models.Order
             public string ShippingStatus { get; set; }
             public DateTime CreatedOn { get; set; }
             public string DeliveryAddress { get; set; }
+            /// <summary>
+            /// True when this order is Pending payment via AmeriaVPos and still needs a
+            /// card payment (self-pay checkout left it unpaid, e.g. InitPayment failed or
+            /// the customer backed out before completing the hosted pay page) - drives the
+            /// mobile Orders list's "Pay" button.
+            /// </summary>
+            public bool RequiresPayment { get; set; }
+            /// <summary>
+            /// The amount still owed by card when <see cref="RequiresPayment"/> is true (raw
+            /// store-currency decimal, same convention as OrderItemModel.UnitPrice - the
+            /// mobile app formats it client-side). Zero otherwise.
+            /// </summary>
+            public decimal AmountDue { get; set; }
         }
 
         public partial record RecurringOrderModel : BaseNopEntityModel

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
@@ -1,13 +1,19 @@
 ﻿@model CheckoutConfirmModel
 <div class="checkout-data">
     @await Component.InvokeAsync("Widget", new { widgetZone = PublicWidgetZones.OpCheckoutConfirmTop })
-    @if (!string.IsNullOrEmpty(Model.MinOrderTotalWarning) || Model.Warnings.Count > 0)
+    @if (!string.IsNullOrEmpty(Model.MinOrderTotalWarning) || !string.IsNullOrEmpty(Model.AllowanceExceededWarning) || Model.Warnings.Count > 0)
     {
         <div class="section confirm-order">
             @if (!string.IsNullOrEmpty(Model.MinOrderTotalWarning))
             {
                 <div>
                     <span class="min-order-warning">@Model.MinOrderTotalWarning</span>
+                </div>
+            }
+            @if (!string.IsNullOrEmpty(Model.AllowanceExceededWarning))
+            {
+                <div>
+                    <span class="allowance-exceeded-warning" style="display:block;padding:10px;margin-bottom:10px;background-color:#fff3cd;color:#856404;border:1px solid #ffeeba;border-radius:4px;">@Model.AllowanceExceededWarning</span>
                 </div>
             }
             @if (Model.Warnings.Count > 0)


### PR DESCRIPTION
Follow-up to #106 — brings the rest of the branch's working tree onto `master` so master matches what runs on dev (the `-local` dev image builds from the working tree).

- `NopCommerce.sln`: register the AmeriaVPos plugin project (was missing from master after #106).
- Company.Company `CheckoutModelFactory_Overriden` + `DependencyRegistrar`: self-pay checkout model wiring.
- `AmeriaVPosPaymentProcessor`, `CheckoutConfirmModel`, `CustomerOrderListModel`, `OpcConfirmOrder`, `OrderApiController`, `ICompanyAllowancePaymentMethod`: self-pay checkout / allowance surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)