### PR TITLE
Vendor delivery Mini App: reminder fixes, push activity log, soft-disable

### DIFF
--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Controllers/VendorDeliveryAppController.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Controllers/VendorDeliveryAppController.cs
@@ -9,6 +9,7 @@ using Nop.Plugin.Notifications.Manager.ScheduledTasks;
 using Nop.Plugin.Notifications.Manager.Services;
 using Nop.Services.Catalog;
 using Nop.Services.Common;
+using Nop.Services.Configuration;
 using Nop.Services.Customers;
 using Nop.Services.Orders;
 using Nop.Services.Vendors;
@@ -37,6 +38,7 @@ public class VendorDeliveryAppController : BaseApiController
     private readonly ICustomerService _customerService;
     private readonly IProductService _productService;
     private readonly PushNotificationService _pushNotificationService;
+    private readonly ISettingService _settingService;
 
     public VendorDeliveryAppController(
         ITelegramMiniAppAuthService telegramMiniAppAuthService,
@@ -45,7 +47,8 @@ public class VendorDeliveryAppController : BaseApiController
         IAddressService addressService,
         ICustomerService customerService,
         IProductService productService,
-        PushNotificationService pushNotificationService)
+        PushNotificationService pushNotificationService,
+        ISettingService settingService)
     {
         _telegramMiniAppAuthService = telegramMiniAppAuthService;
         _orderService = orderService;
@@ -54,38 +57,37 @@ public class VendorDeliveryAppController : BaseApiController
         _customerService = customerService;
         _productService = productService;
         _pushNotificationService = pushNotificationService;
+        _settingService = settingService;
     }
 
     public record OrderCardModel(int Id, string Slot, string Addr, string Addr2, List<string> Items, bool Delivered);
     public record BoardResponse(string VendorName, List<OrderCardModel> Orders);
 
-    private bool TryAuthorize(string token, out int vendorId, out int storeId, out IActionResult errorResult)
+    private record AuthorizeResult(bool Authorized, int VendorId, int StoreId, IActionResult Error);
+
+    private async Task<AuthorizeResult> TryAuthorize(string token)
     {
-        vendorId = 0;
-        storeId = 0;
-        errorResult = null;
+        var notificationManagerSettings = await _settingService.LoadSettingAsync<NotificationManagerSettings>();
+        if (!notificationManagerSettings.VendorDeliveryMiniAppEnabled)
+            return new AuthorizeResult(false, 0, 0, NotFound());
 
         var initData = Request.Headers[InitDataHeaderName].ToString();
         if (!_telegramMiniAppAuthService.TryValidateInitData(initData, out _))
-        {
-            errorResult = Unauthorized(new ErrorMessage("Missing or invalid Telegram session"));
-            return false;
-        }
+            return new AuthorizeResult(false, 0, 0, Unauthorized(new ErrorMessage("Missing or invalid Telegram session")));
 
-        if (!_telegramMiniAppAuthService.TryValidateBoardToken(token, out vendorId, out storeId))
-        {
-            errorResult = Unauthorized(new ErrorMessage("Missing, invalid, or expired board link"));
-            return false;
-        }
+        if (!_telegramMiniAppAuthService.TryValidateBoardToken(token, out var vendorId, out var storeId))
+            return new AuthorizeResult(false, 0, 0, Unauthorized(new ErrorMessage("Missing, invalid, or expired board link")));
 
-        return true;
+        return new AuthorizeResult(true, vendorId, storeId, null);
     }
 
     [HttpGet("orders")]
     public async Task<IActionResult> GetOrders([FromQuery] string token)
     {
-        if (!TryAuthorize(token, out var vendorId, out var storeId, out var error))
-            return error;
+        var auth = await TryAuthorize(token);
+        if (!auth.Authorized)
+            return auth.Error;
+        var (vendorId, storeId) = (auth.VendorId, auth.StoreId);
 
         var vendor = await _vendorService.GetVendorByIdAsync(vendorId);
         if (vendor == null)
@@ -131,8 +133,10 @@ public class VendorDeliveryAppController : BaseApiController
     [HttpPost("orders/{orderId:int}/deliver")]
     public async Task<IActionResult> MarkDelivered(int orderId, [FromQuery] string token)
     {
-        if (!TryAuthorize(token, out var vendorId, out var storeId, out var error))
-            return error;
+        var auth = await TryAuthorize(token);
+        if (!auth.Authorized)
+            return auth.Error;
+        var (vendorId, storeId) = (auth.VendorId, auth.StoreId);
 
         var order = await _orderService.GetOrderByIdAsync(orderId);
         if (order == null || order.StoreId != storeId)

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/EventConsumer/PreDeliveryNudgeSettingConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/EventConsumer/PreDeliveryNudgeSettingConsumer.cs
@@ -17,6 +17,7 @@ namespace Nop.Plugin.Notifications.Manager.EventConsumer;
 public class PreDeliveryNudgeSettingConsumer : IConsumer<EntityUpdatedEvent<Setting>>
 {
     private const string SCHEDULE_DATE_SETTING_NAME = "ordersettings.scheduledate";
+    private const string FEATURE_TOGGLE_SETTING_NAME = "notificationmanagersettings.vendordeliveryminiappenabled";
 
     private readonly PreDeliveryNudgeReconciler _reconciler;
     private readonly ILogger _logger;
@@ -29,7 +30,9 @@ public class PreDeliveryNudgeSettingConsumer : IConsumer<EntityUpdatedEvent<Sett
 
     public async Task HandleEventAsync(EntityUpdatedEvent<Setting> eventMessage)
     {
-        if (!string.Equals(eventMessage.Entity.Name, SCHEDULE_DATE_SETTING_NAME, StringComparison.OrdinalIgnoreCase))
+        var settingName = eventMessage.Entity.Name;
+        if (!string.Equals(settingName, SCHEDULE_DATE_SETTING_NAME, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(settingName, FEATURE_TOGGLE_SETTING_NAME, StringComparison.OrdinalIgnoreCase))
             return;
 
         try

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/PushNotificationSentActivityLogTypeMigration.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/PushNotificationSentActivityLogTypeMigration.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using FluentMigrator;
+using Nop.Core.Domain.Logging;
+using Nop.Data;
+using Nop.Data.Migrations;
+
+namespace Nop.Plugin.Notifications.Manager.Infrastructure;
+
+[NopMigration("2026-07-29 00:00:00:0000001", "Notifications.Manager - Add PublicStore.PushNotificationSent activity log type")]
+[SkipMigrationOnInstall]
+public class PushNotificationSentActivityLogTypeMigration : Migration
+{
+    private const string SYSTEM_KEYWORD = "PublicStore.PushNotificationSent";
+
+    private readonly INopDataProvider _dataProvider;
+
+    public PushNotificationSentActivityLogTypeMigration(INopDataProvider dataProvider)
+    {
+        _dataProvider = dataProvider;
+    }
+
+    public override void Up()
+    {
+        var typeExists = _dataProvider.GetTable<ActivityLogType>()
+            .Any(t => t.SystemKeyword == SYSTEM_KEYWORD);
+
+        if (!typeExists)
+        {
+            _dataProvider.InsertEntityAsync(new ActivityLogType
+            {
+                SystemKeyword = SYSTEM_KEYWORD,
+                Enabled = true,
+                Name = "Public store. Push notification sent"
+            }).GetAwaiter().GetResult();
+        }
+    }
+
+    public override void Down()
+    {
+    }
+}

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/VendorDeliveryMiniAppSettingMigration.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/VendorDeliveryMiniAppSettingMigration.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using FluentMigrator;
+using Nop.Core.Domain.Configuration;
+using Nop.Data;
+using Nop.Data.Migrations;
+
+namespace Nop.Plugin.Notifications.Manager.Infrastructure;
+
+[NopMigration("2026-07-29 00:00:00:0000001", "Notifications.Manager - Add VendorDeliveryMiniAppEnabled soft-disable setting")]
+[SkipMigrationOnInstall]
+public class VendorDeliveryMiniAppSettingMigration : Migration
+{
+    private const string SETTING_NAME = "notificationmanagersettings.vendordeliveryminiappenabled";
+
+    private readonly INopDataProvider _dataProvider;
+
+    public VendorDeliveryMiniAppSettingMigration(INopDataProvider dataProvider)
+    {
+        _dataProvider = dataProvider;
+    }
+
+    public override void Up()
+    {
+        var settingExists = _dataProvider.GetTable<Setting>()
+            .Any(s => s.Name == SETTING_NAME && s.StoreId == 0);
+
+        if (!settingExists)
+        {
+            _dataProvider.InsertEntityAsync(new Setting
+            {
+                Name = SETTING_NAME,
+                Value = "false",
+                StoreId = 0
+            }).GetAwaiter().GetResult();
+        }
+    }
+
+    public override void Down()
+    {
+    }
+}

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/NotificationManagerSettings.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/NotificationManagerSettings.cs
@@ -1,0 +1,14 @@
+using Nop.Core.Configuration;
+
+namespace Nop.Plugin.Notifications.Manager;
+
+public class NotificationManagerSettings : ISettings
+{
+    /// <summary>
+    /// Master switch for the vendor delivery Mini App feature (pre-delivery Telegram nudges +
+    /// the "Open delivery board" link button attached to every vendor Telegram message). Off by
+    /// default - turning it on also requires ExtendedAuthSettings.TelegramMiniAppSigningSecret to
+    /// be configured for the tenant, or board-link minting has nothing to sign with.
+    /// </summary>
+    public bool VendorDeliveryMiniAppEnabled { get; set; }
+}

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/PreDeliveryNudgeJob.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/PreDeliveryNudgeJob.cs
@@ -62,6 +62,13 @@ public class PreDeliveryNudgeJob
         if (!_appSettings.ExtendedAuthSettings.TelegramBotEnabled)
             return;
 
+        // Belt-and-suspenders: PreDeliveryNudgeReconciler already removes this job entirely when
+        // the feature is off, but a job that was already dequeued/mid-flight when the setting
+        // flipped could still reach here - so guard directly too.
+        var notificationManagerSettings = await _settingService.LoadSettingAsync<NotificationManagerSettings>();
+        if (!notificationManagerSettings.VendorDeliveryMiniAppEnabled)
+            return;
+
         if (!TimeSpan.TryParse(deliveryTimeHHmm, out var slotLocal))
         {
             await _logger.ErrorAsync($"Pre-delivery nudge job: unparseable delivery time '{deliveryTimeHHmm}' for store {storeId}");

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/PreDeliveryNudgeReconciler.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/PreDeliveryNudgeReconciler.cs
@@ -54,7 +54,11 @@ public class PreDeliveryNudgeReconciler
     public async Task ReconcileAsync()
     {
         var desiredJobIds = new HashSet<string>();
-        var stores = await _storeService.GetAllStoresAsync();
+
+        var notificationManagerSettings = await _settingService.LoadSettingAsync<NotificationManagerSettings>();
+        var stores = notificationManagerSettings.VendorDeliveryMiniAppEnabled
+            ? await _storeService.GetAllStoresAsync()
+            : Enumerable.Empty<Nop.Core.Domain.Stores.Store>();
 
         foreach (var store in stores)
         {

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/RemindMeNotificationTask.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/RemindMeNotificationTask.cs
@@ -123,29 +123,19 @@ namespace Nop.Plugin.Notifications.Manager.ScheduledTasks
                     new[] {OrderStatus.Complete, OrderStatus.Pending, OrderStatus.Processing},
                     loadLastOrders);
 
-            var lastMonthSameWeekdays = Enumerable.Range(1, 4)
-                .Select(i => DateTime.UtcNow.Date.AddDays(-7 * i))
-                .ToHashSet();
-            
             foreach (var customer in customers)
             {
                 var customerOrdersData = previouslyOrderedProductsByCustomerId[customer.Id];
-                
+
                 // If customer already ordered for today - we're not going to notify
                 if (customerOrdersData.Any() &&
                     customerOrdersData.First().order.ScheduleDate.Date == DateTime.UtcNow.Date)
-                { 
-                    await _logger.InformationAsync($"Customer {customer.Email} already ordered for today, skipping notification", 
+                {
+                    await _logger.InformationAsync($"Customer {customer.Email} already ordered for today, skipping notification",
                         customer: customer);
                     continue;
                 }
-                
-                // Never ordered on this weekday, probably doesn't need a reminder
-                if (!customerOrdersData.Any(o => lastMonthSameWeekdays.Contains(o.order.ScheduleDate.Date)))
-                {
-                    continue;
-                }
-                
+
                 // Prefer the customer's COMPANY time zone (resolved via the CompanyCustomer mapping), else fall
                 // back to the customer/store time zone. Previously this indexed a companies-by-Id dictionary
                 // with the CUSTOMER id, so it never matched and the company zone was silently ignored - every

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/TelegramNotificationSenderTask.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/ScheduledTasks/TelegramNotificationSenderTask.cs
@@ -486,8 +486,11 @@ public class TelegramNotificationSenderTask : IScheduledTask
 
         if(_chatIdToVendor == null)
             await ReloadAllChatMappings();
-        
+
         await HandleBotEvents();
+
+        var notificationManagerSettings = await _setting.LoadSettingAsync<NotificationManagerSettings>();
+        var vendorDeliveryMiniAppEnabled = notificationManagerSettings.VendorDeliveryMiniAppEnabled;
 
         var maxTries = 3;
 
@@ -513,8 +516,10 @@ public class TelegramNotificationSenderTask : IScheduledTask
                     
                     if (vendorChat.Key != null)
                     {
-                        var boardLinkMarkup = await BuildBoardLinkMarkupAsync(
-                            _telegramBotClient, _telegramMiniAppAuthService, vendor.Id, vendorChat.Value.StoreId);
+                        var boardLinkMarkup = vendorDeliveryMiniAppEnabled
+                            ? await BuildBoardLinkMarkupAsync(
+                                _telegramBotClient, _telegramMiniAppAuthService, vendor.Id, vendorChat.Value.StoreId)
+                            : null;
 
                         await _telegramBotClient.SendMessage(chatId: vendorChat.Key.ChatId,
                             messageThreadId: vendorChat.Key.MessageThreadId,

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Services/PushNotificationService.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Services/PushNotificationService.cs
@@ -24,9 +24,12 @@ public class PushNotificationService
     private const string FIREBASE_FAILED_COUNT = nameof(FIREBASE_FAILED_COUNT);
     private const int FIREBASE_MAX_FAILED_COUNT = 3;
     
+    private const string PUSH_NOTIFICATION_SENT_ACTIVITY_KEYWORD = "PublicStore.PushNotificationSent";
+
     private readonly FirebaseMessaging _firebaseMessaging;
     private readonly ICustomerService _customerService;
     private readonly IGenericAttributeService _genericAttributeService;
+    private readonly ICustomerActivityService _customerActivityService;
     private readonly ILogger _logger;
 
     
@@ -81,6 +84,10 @@ public class PushNotificationService
                 Notification = new Notification() { Title = title, Body = body },
                 Data = data ?? new Dictionary<string, string>()
             });
+
+            await _customerActivityService.InsertActivityAsync(customer,
+                PUSH_NOTIFICATION_SENT_ACTIVITY_KEYWORD,
+                $"{notificationType}: {title} - {body}");
         }
         catch (FirebaseMessagingException fme)
         {
@@ -100,11 +107,13 @@ public class PushNotificationService
         }
     }
     
-    public PushNotificationService(FirebaseApp firebaseApp, ICustomerService customerService, ILogger logger, IGenericAttributeService genericAttributeService)
+    public PushNotificationService(FirebaseApp firebaseApp, ICustomerService customerService, ILogger logger,
+        IGenericAttributeService genericAttributeService, ICustomerActivityService customerActivityService)
     {
         _customerService = customerService;
         _logger = logger;
         _genericAttributeService = genericAttributeService;
+        _customerActivityService = customerActivityService;
         _firebaseMessaging = FirebaseMessaging.GetMessaging(firebaseApp);
     }
 }

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Services/TelegramMiniAppAuthService.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Services/TelegramMiniAppAuthService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -20,27 +21,32 @@ public class TelegramMiniAppAuthService : ITelegramMiniAppAuthService
         _appSettings = appSettings;
     }
 
-    private class BoardTokenPayload
-    {
-        public int VendorId { get; set; }
-        public int StoreId { get; set; }
-        public long ExpiresAtUnixSeconds { get; set; }
-    }
+    // Telegram restricts the `startapp` value to [A-Za-z0-9_-], max 64 characters (found the
+    // hard way - a JSON+dot-separated token got rejected client-side as "start param invalid").
+    // So the token is packed binary, not JSON: 8-byte payload (ushort vendorId, ushort storeId,
+    // uint expiresAtUnixSeconds, all big-endian) + an 8-byte truncated HMAC-SHA256 tag, base64url
+    // -encoded as one 16-byte blob (~22 chars, well under the limit, no separator needed since
+    // both fields are fixed-width). Truncating the MAC to 64 bits is fine for this threat model -
+    // worst case is viewing/marking one vendor's non-sensitive order list until the token expires.
+    private const int PayloadLength = 8;
+    private const int SignatureLength = 8;
 
     public string MintBoardToken(int vendorId, int storeId)
     {
-        var payload = new BoardTokenPayload
-        {
-            VendorId = vendorId,
-            StoreId = storeId,
-            ExpiresAtUnixSeconds = DateTimeOffset.UtcNow.Add(BoardTokenLifetime).ToUnixTimeSeconds()
-        };
+        var expiresAt = (uint)DateTimeOffset.UtcNow.Add(BoardTokenLifetime).ToUnixTimeSeconds();
 
-        var payloadBytes = JsonSerializer.SerializeToUtf8Bytes(payload);
-        var payloadPart = Base64UrlEncode(payloadBytes);
-        var signaturePart = Base64UrlEncode(SignBoardTokenPayload(payloadBytes));
+        var payloadBytes = new byte[PayloadLength];
+        BinaryPrimitives.WriteUInt16BigEndian(payloadBytes.AsSpan(0, 2), (ushort)vendorId);
+        BinaryPrimitives.WriteUInt16BigEndian(payloadBytes.AsSpan(2, 2), (ushort)storeId);
+        BinaryPrimitives.WriteUInt32BigEndian(payloadBytes.AsSpan(4, 4), expiresAt);
 
-        return $"{payloadPart}.{signaturePart}";
+        var signature = SignBoardTokenPayload(payloadBytes)[..SignatureLength];
+
+        var tokenBytes = new byte[PayloadLength + SignatureLength];
+        payloadBytes.CopyTo(tokenBytes, 0);
+        signature.CopyTo(tokenBytes, PayloadLength);
+
+        return Base64UrlEncode(tokenBytes);
     }
 
     public bool TryValidateBoardToken(string token, out int vendorId, out int storeId)
@@ -51,44 +57,32 @@ public class TelegramMiniAppAuthService : ITelegramMiniAppAuthService
         if (string.IsNullOrWhiteSpace(token))
             return false;
 
-        var parts = token.Split('.');
-        if (parts.Length != 2)
-            return false;
-
-        byte[] payloadBytes;
-        byte[] providedSignature;
+        byte[] tokenBytes;
         try
         {
-            payloadBytes = Base64UrlDecode(parts[0]);
-            providedSignature = Base64UrlDecode(parts[1]);
+            tokenBytes = Base64UrlDecode(token);
         }
         catch (FormatException)
         {
             return false;
         }
 
-        var expectedSignature = SignBoardTokenPayload(payloadBytes);
+        if (tokenBytes.Length != PayloadLength + SignatureLength)
+            return false;
+
+        var payloadBytes = tokenBytes.AsSpan(0, PayloadLength).ToArray();
+        var providedSignature = tokenBytes.AsSpan(PayloadLength, SignatureLength).ToArray();
+
+        var expectedSignature = SignBoardTokenPayload(payloadBytes)[..SignatureLength];
         if (!CryptographicOperations.FixedTimeEquals(providedSignature, expectedSignature))
             return false;
 
-        BoardTokenPayload payload;
-        try
-        {
-            payload = JsonSerializer.Deserialize<BoardTokenPayload>(payloadBytes);
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-
-        if (payload == null)
+        var expiresAt = BinaryPrimitives.ReadUInt32BigEndian(payloadBytes.AsSpan(4, 4));
+        if (DateTimeOffset.UtcNow.ToUnixTimeSeconds() > expiresAt)
             return false;
 
-        if (DateTimeOffset.UtcNow.ToUnixTimeSeconds() > payload.ExpiresAtUnixSeconds)
-            return false;
-
-        vendorId = payload.VendorId;
-        storeId = payload.StoreId;
+        vendorId = BinaryPrimitives.ReadUInt16BigEndian(payloadBytes.AsSpan(0, 2));
+        storeId = BinaryPrimitives.ReadUInt16BigEndian(payloadBytes.AsSpan(2, 2));
         return true;
     }
 

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/plugin.json
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/plugin.json
@@ -2,7 +2,7 @@
   "Group": "Notifications Manager",
   "FriendlyName": "Notifications Manager",
   "SystemName": "NotificationsManager",
-  "Version": "1.6",
+  "Version": "1.7",
   "SupportedVersions": [ "4.30", "4.40", "4.50" ],
   "Author": "Edgar Isajanyan",
   "DisplayOrder": 1,

--- a/src/Plugins/Nop.Plugin.Notifications.Manager/plugin.json
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/plugin.json
@@ -2,7 +2,7 @@
   "Group": "Notifications Manager",
   "FriendlyName": "Notifications Manager",
   "SystemName": "NotificationsManager",
-  "Version": "1.5",
+  "Version": "1.6",
   "SupportedVersions": [ "4.30", "4.40", "4.50" ],
   "Author": "Edgar Isajanyan",
   "DisplayOrder": 1,


### PR DESCRIPTION
## Summary
- Fix board token to fit Telegram's `startapp` charset/length constraints
- Log a `PublicStore.PushNotificationSent` customer activity entry on every successful push send
- Remove the "never ordered on this weekday" gate from `RemindMeNotificationTask` so every opted-in customer gets reminded at their slot regardless of order history
- Add `NotificationManagerSettings.VendorDeliveryMiniAppEnabled` (default off) to soft-disable the vendor delivery Mini App / pre-delivery nudge feature at every call site, so a tenant without `TelegramMiniAppSigningSecret` configured behaves exactly as before this feature existed instead of throwing

## Test plan
- [x] Full solution builds clean (0 errors)
- [x] Verified on prod-mysnacks: RemindMe reminder fired and delivered at customer's configured slot, `PublicStore.PushNotificationSent` activity logged
- [x] Confirmed pre-delivery nudge Hangfire jobs registered per-tenant via Hangfire's own job storage
- [ ] Confirm soft-disable setting after deploy (should default to disabled everywhere until explicitly enabled with a signing secret configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)