### PR TITLE
Fix duplicate FluentMigrator version (PR #108 outage hotfix)

### DIFF
--- a/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/VendorDeliveryMiniAppSettingMigration.cs
+++ b/src/Plugins/Nop.Plugin.Notifications.Manager/Infrastructure/VendorDeliveryMiniAppSettingMigration.cs
@@ -6,7 +6,7 @@ using Nop.Data.Migrations;
 
 namespace Nop.Plugin.Notifications.Manager.Infrastructure;
 
-[NopMigration("2026-07-29 00:00:00:0000001", "Notifications.Manager - Add VendorDeliveryMiniAppEnabled soft-disable setting")]
+[NopMigration("2026-07-29 00:00:00:0000002", "Notifications.Manager - Add VendorDeliveryMiniAppEnabled soft-disable setting")]
 [SkipMigrationOnInstall]
 public class VendorDeliveryMiniAppSettingMigration : Migration
 {


### PR DESCRIPTION
## Summary
- Fixes a duplicate FluentMigrator version (`2026-07-29 00:00:00:0000001` used by two migrations in PR #108), which caused `DuplicateMigrationException` on app startup and took down dev + all 4 prod tenants after that PR's image was deployed.
- Rolled back to the previous known-good tag immediately to restore service; this PR contains only the 1-line fix (bump the second migration to `:0000002`).

## Test plan
- [x] Full solution builds clean
- [ ] Deploy and confirm app boots successfully everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)