### PR TITLE
Per-company weekly vendor schedule + day-off calendar

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Companies/CompanyVendorDayOff.cs
+++ b/src/Libraries/Nop.Core/Domain/Companies/CompanyVendorDayOff.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Nop.Core.Domain.Companies
+{
+    /// <summary>
+    /// Represents a per-date day-off override for a vendor under a company. One row per
+    /// (CompanyId, VendorId, Date). Restoring a day flips IsOff back to false and stamps
+    /// RestoredOnUtc rather than deleting the row, so there's a visible history.
+    /// </summary>
+    public partial class CompanyVendorDayOff : BaseEntity
+    {
+        /// <summary>
+        /// Gets or sets the company identifier
+        /// </summary>
+        public int CompanyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vendor identifier
+        /// </summary>
+        public int VendorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the company-local calendar date (time component zeroed)
+        /// </summary>
+        public DateTime Date { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the vendor is currently off on this date
+        /// </summary>
+        public bool IsOff { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time (UTC) the day was marked off
+        /// </summary>
+        public DateTime CreatedOnUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time (UTC) the day was restored, if it has been
+        /// </summary>
+        public DateTime? RestoredOnUtc { get; set; }
+    }
+}

--- a/src/Libraries/Nop.Core/Domain/Companies/CompanyVendorWorkingDay.cs
+++ b/src/Libraries/Nop.Core/Domain/Companies/CompanyVendorWorkingDay.cs
@@ -1,0 +1,25 @@
+namespace Nop.Core.Domain.Companies
+{
+    /// <summary>
+    /// Represents a working day of week for a vendor under a company. Any row for a
+    /// given (CompanyId, VendorId) pair restricts that pair to only the recorded days;
+    /// no rows at all for the pair means the vendor works every day (the default).
+    /// </summary>
+    public partial class CompanyVendorWorkingDay : BaseEntity
+    {
+        /// <summary>
+        /// Gets or sets the company identifier
+        /// </summary>
+        public int CompanyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vendor identifier
+        /// </summary>
+        public int VendorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the day of week (System.DayOfWeek numeric value, 0=Sunday..6=Saturday)
+        /// </summary>
+        public int DayOfWeekId { get; set; }
+    }
+}

--- a/src/Libraries/Nop.Services/Catalog/IProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IProductService.cs
@@ -176,7 +176,8 @@ namespace Nop.Services.Catalog
             bool showHidden = false,
             bool? overridePublished = null,
             bool searchCustomerVendors = false,
-            bool? onlyDiscounted = false);
+            bool? onlyDiscounted = false,
+            DateTime? availabilityDate = null);
 
         /// <summary>
         /// Gets products by product attribute

--- a/src/Libraries/Nop.Services/Catalog/ProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductService.cs
@@ -65,6 +65,7 @@ namespace Nop.Services.Catalog
         protected readonly IWorkContext _workContext;
         protected readonly LocalizationSettings _localizationSettings;
         private readonly ICompanyService _companyService;
+        private readonly ICompanyVendorScheduleService _companyVendorScheduleService;
 
         #endregion
 
@@ -104,7 +105,8 @@ namespace Nop.Services.Catalog
             IStoreMappingService storeMappingService,
             IWorkContext workContext,
             LocalizationSettings localizationSettings,
-            ICompanyService companyService)
+            ICompanyService companyService,
+            ICompanyVendorScheduleService companyVendorScheduleService)
         {
             _catalogSettings = catalogSettings;
             _commonSettings = commonSettings;
@@ -141,6 +143,7 @@ namespace Nop.Services.Catalog
             _workContext = workContext;
             _localizationSettings = localizationSettings;
             _companyService = companyService;
+            _companyVendorScheduleService = companyVendorScheduleService;
         }
 
         #endregion
@@ -807,7 +810,8 @@ namespace Nop.Services.Catalog
             bool showHidden = false,
             bool? overridePublished = null,
             bool searchCustomerVendors = false,
-            bool? onlyDiscounted = false)
+            bool? onlyDiscounted = false,
+            DateTime? availabilityDate = null)
         {
             //some databases don't support int.MaxValue
             if (pageSize == int.MaxValue)
@@ -856,6 +860,18 @@ namespace Nop.Services.Catalog
                 if (vendors.Length > 0)
                 {
                     productsQuery = productsQuery.Where(p => vendors.Contains(p.VendorId));
+                }
+
+                // Hide products whose vendor is off/non-working for the customer's currently
+                // selected delivery date (weekly schedule + day-off overrides). Only applied when
+                // the caller passes a date - existing callers (admin pickers, etc.) are unaffected.
+                if (availabilityDate.HasValue && company != null)
+                {
+                    var unavailableVendorIds = await _companyVendorScheduleService.GetUnavailableVendorIdsAsync(company.Id, availabilityDate.Value);
+                    if (unavailableVendorIds.Count > 0)
+                    {
+                        productsQuery = productsQuery.Where(p => !unavailableVendorIds.Contains(p.VendorId));
+                    }
                 }
             }
 

--- a/src/Libraries/Nop.Services/Companies/CompanyVendorScheduleService.cs
+++ b/src/Libraries/Nop.Services/Companies/CompanyVendorScheduleService.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Nop.Core.Domain.Companies;
+using Nop.Data;
+
+namespace Nop.Services.Companies
+{
+    /// <summary>
+    /// Company vendor schedule service
+    /// </summary>
+    public partial class CompanyVendorScheduleService : ICompanyVendorScheduleService
+    {
+        #region Fields
+
+        private readonly IRepository<CompanyVendorWorkingDay> _workingDayRepository;
+        private readonly IRepository<CompanyVendorDayOff> _dayOffRepository;
+
+        #endregion
+
+        #region Ctor
+
+        public CompanyVendorScheduleService(
+            IRepository<CompanyVendorWorkingDay> workingDayRepository,
+            IRepository<CompanyVendorDayOff> dayOffRepository)
+        {
+            _workingDayRepository = workingDayRepository;
+            _dayOffRepository = dayOffRepository;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the configured working days for a company-vendor pair. An empty result
+        /// means the vendor is available every day (the default).
+        /// </summary>
+        public virtual async Task<IList<CompanyVendorWorkingDay>> GetWorkingDaysAsync(int companyId, int vendorId)
+        {
+            return await _workingDayRepository.GetAllAsync(query =>
+            {
+                return query
+                    .Where(wd => wd.CompanyId == companyId && wd.VendorId == vendorId)
+                    .OrderBy(wd => wd.DayOfWeekId);
+            });
+        }
+
+        /// <summary>
+        /// Replaces the working-day pattern for a company-vendor pair. Passing an empty
+        /// list clears the pattern, meaning the vendor becomes available every day.
+        /// </summary>
+        public virtual async Task SetWorkingDaysAsync(int companyId, int vendorId, IList<DayOfWeek> daysOfWeek)
+        {
+            var existing = await GetWorkingDaysAsync(companyId, vendorId);
+            if (existing.Any())
+                await _workingDayRepository.DeleteAsync(existing);
+
+            if (daysOfWeek == null || !daysOfWeek.Any())
+                return;
+
+            var newRows = daysOfWeek
+                .Distinct()
+                .Select(d => new CompanyVendorWorkingDay
+                {
+                    CompanyId = companyId,
+                    VendorId = vendorId,
+                    DayOfWeekId = (int)d
+                })
+                .ToList();
+
+            await _workingDayRepository.InsertAsync(newRows);
+        }
+
+        /// <summary>
+        /// Gets the day-off record for a specific date, if the vendor is currently off that date
+        /// </summary>
+        public virtual async Task<CompanyVendorDayOff> GetDayOffAsync(int companyId, int vendorId, DateTime date)
+        {
+            var records = await _dayOffRepository.GetAllAsync(query =>
+            {
+                return query.Where(d =>
+                    d.CompanyId == companyId &&
+                    d.VendorId == vendorId &&
+                    d.Date == date.Date &&
+                    d.IsOff);
+            });
+
+            return records.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets all day-off records (including restored ones) for a company-vendor pair
+        /// within a date range, for calendar rendering
+        /// </summary>
+        public virtual async Task<IList<CompanyVendorDayOff>> GetDaysOffAsync(int companyId, int vendorId, DateTime fromDate, DateTime toDate)
+        {
+            var from = fromDate.Date;
+            var to = toDate.Date;
+
+            return await _dayOffRepository.GetAllAsync(query =>
+            {
+                return query
+                    .Where(d => d.CompanyId == companyId && d.VendorId == vendorId && d.Date >= from && d.Date <= to)
+                    .OrderBy(d => d.Date);
+            });
+        }
+
+        /// <summary>
+        /// Marks a specific calendar date off for a company-vendor pair
+        /// </summary>
+        public virtual async Task MarkDayOffAsync(int companyId, int vendorId, DateTime date)
+        {
+            var existing = await GetExistingRecordAsync(companyId, vendorId, date);
+
+            if (existing != null)
+            {
+                existing.IsOff = true;
+                existing.CreatedOnUtc = DateTime.UtcNow;
+                existing.RestoredOnUtc = null;
+                await _dayOffRepository.UpdateAsync(existing);
+                return;
+            }
+
+            await _dayOffRepository.InsertAsync(new CompanyVendorDayOff
+            {
+                CompanyId = companyId,
+                VendorId = vendorId,
+                Date = date.Date,
+                IsOff = true,
+                CreatedOnUtc = DateTime.UtcNow,
+                RestoredOnUtc = null
+            });
+        }
+
+        /// <summary>
+        /// Restores a previously marked-off day for a company-vendor pair
+        /// </summary>
+        public virtual async Task RestoreDayAsync(int companyId, int vendorId, DateTime date)
+        {
+            var existing = await GetDayOffAsync(companyId, vendorId, date);
+            if (existing == null)
+                return;
+
+            existing.IsOff = false;
+            existing.RestoredOnUtc = DateTime.UtcNow;
+            await _dayOffRepository.UpdateAsync(existing);
+        }
+
+        /// <summary>
+        /// Determines whether a vendor is available for a company on a given date,
+        /// combining the day-off override with the weekly working-day pattern
+        /// </summary>
+        public virtual async Task<bool> IsVendorAvailableAsync(int companyId, int vendorId, DateTime date)
+        {
+            var dayOff = await GetDayOffAsync(companyId, vendorId, date);
+            if (dayOff != null)
+                return false;
+
+            var workingDays = await GetWorkingDaysAsync(companyId, vendorId);
+            if (!workingDays.Any())
+                return true;
+
+            return workingDays.Any(wd => wd.DayOfWeekId == (int)date.DayOfWeek);
+        }
+
+        #endregion
+
+        #region Utilities
+
+        /// <summary>
+        /// Finds the existing day-off record for a specific date regardless of its
+        /// current IsOff state, so marking a day off again after a restore updates the
+        /// same row instead of creating a duplicate.
+        /// </summary>
+        protected virtual async Task<CompanyVendorDayOff> GetExistingRecordAsync(int companyId, int vendorId, DateTime date)
+        {
+            var records = await _dayOffRepository.GetAllAsync(query =>
+            {
+                return query.Where(d =>
+                    d.CompanyId == companyId &&
+                    d.VendorId == vendorId &&
+                    d.Date == date.Date);
+            });
+
+            return records.FirstOrDefault();
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/Nop.Services/Companies/CompanyVendorScheduleService.cs
+++ b/src/Libraries/Nop.Services/Companies/CompanyVendorScheduleService.cs
@@ -165,6 +165,39 @@ namespace Nop.Services.Companies
             return workingDays.Any(wd => wd.DayOfWeekId == (int)date.DayOfWeek);
         }
 
+        /// <summary>
+        /// Gets the set of vendor identifiers that are unavailable for a company on a given date
+        /// (via a day-off override, or a configured weekly pattern that excludes that weekday).
+        /// Computed in a constant number of queries regardless of how many vendors the company
+        /// has, for use on hot catalog-browsing paths.
+        /// </summary>
+        public virtual async Task<HashSet<int>> GetUnavailableVendorIdsAsync(int companyId, DateTime date)
+        {
+            var targetDate = date.Date;
+            var dayOfWeek = (int)date.DayOfWeek;
+
+            var daysOffToday = await _dayOffRepository.GetAllAsync(query =>
+            {
+                return query.Where(d => d.CompanyId == companyId && d.Date == targetDate && d.IsOff);
+            });
+
+            var unavailable = daysOffToday.Select(d => d.VendorId).ToHashSet();
+
+            var allWorkingDays = await _workingDayRepository.GetAllAsync(query =>
+            {
+                return query.Where(wd => wd.CompanyId == companyId);
+            });
+
+            var vendorsWithPatternExcludingToday = allWorkingDays
+                .GroupBy(wd => wd.VendorId)
+                .Where(g => g.All(wd => wd.DayOfWeekId != dayOfWeek))
+                .Select(g => g.Key);
+
+            unavailable.UnionWith(vendorsWithPatternExcludingToday);
+
+            return unavailable;
+        }
+
         #endregion
 
         #region Utilities

--- a/src/Libraries/Nop.Services/Companies/ICompanyVendorScheduleService.cs
+++ b/src/Libraries/Nop.Services/Companies/ICompanyVendorScheduleService.cs
@@ -74,5 +74,16 @@ namespace Nop.Services.Companies
         /// <param name="date">Company-local calendar date</param>
         /// <returns>True if the vendor is available on that date</returns>
         Task<bool> IsVendorAvailableAsync(int companyId, int vendorId, DateTime date);
+
+        /// <summary>
+        /// Gets the set of vendor identifiers that are unavailable for a company on a given date
+        /// (via a day-off override, or a configured weekly pattern that excludes that weekday).
+        /// Computed in a constant number of queries regardless of how many vendors the company
+        /// has, for use on hot catalog-browsing paths.
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="date">Company-local calendar date</param>
+        /// <returns>Unavailable vendor identifiers</returns>
+        Task<HashSet<int>> GetUnavailableVendorIdsAsync(int companyId, DateTime date);
     }
 }

--- a/src/Libraries/Nop.Services/Companies/ICompanyVendorScheduleService.cs
+++ b/src/Libraries/Nop.Services/Companies/ICompanyVendorScheduleService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nop.Core.Domain.Companies;
+
+namespace Nop.Services.Companies
+{
+    /// <summary>
+    /// Company vendor schedule service interface — the weekly recurring working-day
+    /// pattern and per-date day-off overrides for a (company, vendor) pair
+    /// </summary>
+    public partial interface ICompanyVendorScheduleService
+    {
+        /// <summary>
+        /// Gets the configured working days for a company-vendor pair. An empty result
+        /// means the vendor is available every day (the default).
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <returns>Working days</returns>
+        Task<IList<CompanyVendorWorkingDay>> GetWorkingDaysAsync(int companyId, int vendorId);
+
+        /// <summary>
+        /// Replaces the working-day pattern for a company-vendor pair. Passing an empty
+        /// list clears the pattern, meaning the vendor becomes available every day.
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="daysOfWeek">The days of week the vendor works</param>
+        Task SetWorkingDaysAsync(int companyId, int vendorId, IList<DayOfWeek> daysOfWeek);
+
+        /// <summary>
+        /// Gets the day-off record for a specific date, if the vendor is currently off that date
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="date">Company-local calendar date</param>
+        /// <returns>The day-off record, or null if the vendor is not off that date</returns>
+        Task<CompanyVendorDayOff> GetDayOffAsync(int companyId, int vendorId, DateTime date);
+
+        /// <summary>
+        /// Gets all day-off records (including restored ones) for a company-vendor pair
+        /// within a date range, for calendar rendering
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="fromDate">Range start (inclusive)</param>
+        /// <param name="toDate">Range end (inclusive)</param>
+        /// <returns>Day-off records</returns>
+        Task<IList<CompanyVendorDayOff>> GetDaysOffAsync(int companyId, int vendorId, DateTime fromDate, DateTime toDate);
+
+        /// <summary>
+        /// Marks a specific calendar date off for a company-vendor pair
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="date">Company-local calendar date</param>
+        Task MarkDayOffAsync(int companyId, int vendorId, DateTime date);
+
+        /// <summary>
+        /// Restores a previously marked-off day for a company-vendor pair
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="date">Company-local calendar date</param>
+        Task RestoreDayAsync(int companyId, int vendorId, DateTime date);
+
+        /// <summary>
+        /// Determines whether a vendor is available for a company on a given date,
+        /// combining the day-off override with the weekly working-day pattern
+        /// </summary>
+        /// <param name="companyId">Company identifier</param>
+        /// <param name="vendorId">Vendor identifier</param>
+        /// <param name="date">Company-local calendar date</param>
+        /// <returns>True if the vendor is available on that date</returns>
+        Task<bool> IsVendorAvailableAsync(int companyId, int vendorId, DateTime date);
+    }
+}

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Controllers/CompanyController.cs
@@ -69,6 +69,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
         private readonly IAddressService _addressService;
         private readonly IVendorService _vendorService;
         private readonly ICompanyAddressService _companyAddressService;
+        private readonly ICompanyVendorScheduleService _companyVendorScheduleService;
 
         #endregion
 
@@ -97,7 +98,8 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
             IAddressAttributeParser addressAttributeParser,
             IAddressService addressService,
             IVendorService vendorService,
-            ICompanyAddressService companyAddressService)
+            ICompanyAddressService companyAddressService,
+            ICompanyVendorScheduleService companyVendorScheduleService)
         {
             _aclService = aclService;
             _companyModelFactory = companyModelFactory;
@@ -123,6 +125,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
             _addressService = addressService;
             _vendorService = vendorService;
             _companyAddressService = companyAddressService;
+            _companyVendorScheduleService = companyVendorScheduleService;
         }
 
         #endregion
@@ -570,6 +573,85 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Controllers
             var model = await _companyModelFactory.PrepareAddVendorToCompanyListModelAsync(searchModel);
 
             return Json(model);
+        }
+
+        #endregion
+
+        #region vendor schedule
+
+        public virtual async Task<IActionResult> VendorSchedulePopup(int companyId, int vendorId)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCategories))
+                return AccessDeniedView();
+
+            var model = await _companyModelFactory.PrepareCompanyVendorScheduleModelAsync(companyId, vendorId);
+
+            return View("~/Plugins/Company.Company/Views/VendorSchedulePopup.cshtml", model);
+        }
+
+        [HttpPost]
+        public virtual async Task<IActionResult> VendorScheduleSaveWorkingDays(int companyId, int vendorId, List<int> days)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCategories))
+                return Json(new { success = false, message = "Access denied." });
+
+            var daysOfWeek = (days ?? new List<int>())
+                .Distinct()
+                .Select(d => (DayOfWeek)d)
+                .ToList();
+
+            await _companyVendorScheduleService.SetWorkingDaysAsync(companyId, vendorId, daysOfWeek);
+
+            return Json(new { success = true });
+        }
+
+        [HttpPost]
+        public virtual async Task<IActionResult> VendorScheduleGetMonth(int companyId, int vendorId, int year, int month)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCategories))
+                return Json(new { success = false, message = "Access denied." });
+
+            var fromDate = new DateTime(year, month, 1);
+            var toDate = fromDate.AddMonths(1).AddDays(-1);
+
+            var daysOff = await _companyVendorScheduleService.GetDaysOffAsync(companyId, vendorId, fromDate, toDate);
+
+            return Json(new
+            {
+                success = true,
+                daysOff = daysOff
+                    .Where(d => d.IsOff)
+                    .Select(d => d.Date.ToString("yyyy-MM-dd"))
+                    .ToArray()
+            });
+        }
+
+        [HttpPost]
+        public virtual async Task<IActionResult> VendorScheduleMarkDayOff(int companyId, int vendorId, string date)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCategories))
+                return Json(new { success = false, message = "Access denied." });
+
+            if (!DateTime.TryParse(date, out var parsedDate))
+                return Json(new { success = false, message = "Invalid date." });
+
+            await _companyVendorScheduleService.MarkDayOffAsync(companyId, vendorId, parsedDate);
+
+            return Json(new { success = true });
+        }
+
+        [HttpPost]
+        public virtual async Task<IActionResult> VendorScheduleRestoreDay(int companyId, int vendorId, string date)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermissionProvider.ManageCategories))
+                return Json(new { success = false, message = "Access denied." });
+
+            if (!DateTime.TryParse(date, out var parsedDate))
+                return Json(new { success = false, message = "Invalid date." });
+
+            await _companyVendorScheduleService.RestoreDayAsync(companyId, vendorId, parsedDate);
+
+            return Json(new { success = true });
         }
 
         #endregion

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Factories/CompanyModelFactory.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Factories/CompanyModelFactory.cs
@@ -54,6 +54,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Factories
         private readonly IAddressModelFactory _addressModelFactory;
         private readonly ICompanyAddressService _companyAddressService;
         private readonly IAddressService _addressService;
+        private readonly ICompanyVendorScheduleService _companyVendorScheduleService;
 
         #endregion
 
@@ -71,7 +72,8 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Factories
             IAddressModelFactory addressModelFactory,
             IVendorService vendorService,
             ICompanyAddressService companyAddressService,
-            IAddressService addressService)
+            IAddressService addressService,
+            ICompanyVendorScheduleService companyVendorScheduleService)
         {
             _companyService = companyService;
             _localizationService = localizationService;
@@ -86,6 +88,7 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Factories
             _vendorService = vendorService;
             _companyAddressService = companyAddressService;
             _addressService = addressService;
+            _companyVendorScheduleService = companyVendorScheduleService;
         }
 
         #endregion
@@ -338,6 +341,20 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Factories
             });
 
             return model;
+        }
+
+        public virtual async Task<CompanyVendorScheduleModel> PrepareCompanyVendorScheduleModelAsync(int companyId, int vendorId)
+        {
+            var vendor = await _vendorService.GetVendorByIdAsync(vendorId);
+            var workingDays = await _companyVendorScheduleService.GetWorkingDaysAsync(companyId, vendorId);
+
+            return new CompanyVendorScheduleModel
+            {
+                CompanyId = companyId,
+                VendorId = vendorId,
+                VendorName = vendor?.Name,
+                WorkingDays = workingDays.Select(wd => wd.DayOfWeekId).ToList()
+            };
         }
 
         public virtual async Task<CustomerAddressListModel> PrepareCompanyCustomerAddressListModelAsync(CustomerAddressSearchModel searchModel, Core.Domain.Companies.Company company)

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Factories/ICompanyModelFactory.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Factories/ICompanyModelFactory.cs
@@ -23,5 +23,6 @@ namespace Nop.Plugin.Company.Company.Areas.Admin.Factories
         Task<CompanyAddressListModel> PrepareCompanyAddressListModelAsync(CompanyAddressSearchModel searchModel, Core.Domain.Companies.Company company);
         Task<CompanyAddressModel> PrepareCompanyAddressModelAsync(CompanyAddressModel model,
            Core.Domain.Companies.Company company, Address address, bool excludeProperties = false);
+        Task<CompanyVendorScheduleModel> PrepareCompanyVendorScheduleModelAsync(int companyId, int vendorId);
     }
 }

--- a/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Models/CompanyVendorScheduleModel.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Areas/Admin/Models/CompanyVendorScheduleModel.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Company.Company.Areas.Admin.Models
+{
+    /// <summary>
+    /// The weekly working-day pattern for a company-vendor pair, shown in the Schedule popup
+    /// </summary>
+    public partial record CompanyVendorScheduleModel : BaseNopModel
+    {
+        public int CompanyId { get; set; }
+
+        public int VendorId { get; set; }
+
+        public string VendorName { get; set; }
+
+        /// <summary>
+        /// The configured working days (System.DayOfWeek numeric values). Empty means the
+        /// vendor is available every day.
+        /// </summary>
+        public IList<int> WorkingDays { get; set; } = new List<int>();
+    }
+
+    /// <summary>
+    /// A single day's off-status, used by the calendar's per-month AJAX response
+    /// </summary>
+    public partial record CompanyVendorDayOffModel : BaseNopModel
+    {
+        /// <summary>
+        /// Date in "yyyy-MM-dd" format
+        /// </summary>
+        public string Date { get; set; }
+
+        public bool IsOff { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Company.Company/Controllers/CheckoutController_Overriden.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Controllers/CheckoutController_Overriden.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -110,23 +112,28 @@ public class CheckoutController_Overriden: CheckoutController
         _shoppingCartService = shoppingCartService;
     }
 
-    public override async Task<IActionResult> OpcSaveShipping(CheckoutShippingAddressModel model, 
+    public override async Task<IActionResult> OpcSaveShipping(CheckoutShippingAddressModel model,
         IFormCollection form)
     {
         var currentCustomer = await _workContext.GetCurrentCustomerAsync();
         var currentStore = await _storeContext.GetCurrentStoreAsync();
         var deliveryTime = await _deliveryTimeStorageService.GetSelectedDeliveryTimeAsync(
-            currentCustomer, 
+            currentCustomer,
             currentStore.Id);
 
+        // Return the same { error = 1, message = ... } contract the base OPC actions use on
+        // failure (see base.OpcSaveShipping's own catch block) instead of throwing - throwing
+        // here escapes the base method's try/catch entirely (this code runs before base is ever
+        // called), which the one-page checkout JS can't render as a normal validation error and
+        // instead surfaces as a raw unhandled-exception error page.
         if (!deliveryTime.HasValue)
         {
-            throw new Exception("Please select a delivery time from the header before proceeding with checkout.");
+            return Json(new { error = 1, message = "Please select a delivery time from the header before proceeding with checkout." });
         }
 
         if (!await _deliveryTimeService.IsDeliveryTimeAvailableAsync(deliveryTime.Value))
         {
-            throw new Exception("The selected delivery time is no longer available. Please select a new delivery time.");
+            return Json(new { error = 1, message = "The selected delivery time is no longer available. Please select a new delivery time." });
         }
 
         var company = await _companyService.GetCompanyByCustomerIdAsync(currentCustomer.Id);
@@ -135,6 +142,7 @@ public class CheckoutController_Overriden: CheckoutController
             // deliveryTime is stored as company-local wall-clock time (see OpcConfirmOrder), so
             // its Date is already the company-local calendar date - no timezone conversion needed.
             var cart = await _shoppingCartService.GetShoppingCartAsync(currentCustomer, ShoppingCartType.ShoppingCart, currentStore.Id);
+            var unavailableProductNames = new System.Collections.Generic.List<string>();
             foreach (var item in cart)
             {
                 var product = await _productService.GetProductByIdAsync(item.ProductId);
@@ -143,8 +151,17 @@ public class CheckoutController_Overriden: CheckoutController
 
                 if (!await _companyVendorScheduleService.IsVendorAvailableAsync(company.Id, product.VendorId, deliveryTime.Value.Date))
                 {
-                    throw new Exception($"'{product.Name}' is not available for delivery on the selected date. Please remove it from your cart or choose a different delivery time.");
+                    unavailableProductNames.Add(product.Name);
                 }
+            }
+
+            if (unavailableProductNames.Any())
+            {
+                return Json(new
+                {
+                    error = 1,
+                    message = $"The following items are not available for delivery on the selected date: {string.Join(", ", unavailableProductNames)}. Please remove them from your cart or choose a different delivery time."
+                });
             }
         }
 

--- a/src/Plugins/Nop.Plugin.Company.Company/Controllers/CheckoutController_Overriden.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Controllers/CheckoutController_Overriden.cs
@@ -37,11 +37,15 @@ public class CheckoutController_Overriden: CheckoutController
     private readonly IDeliveryTimeService _deliveryTimeService;
     private readonly IDateTimeHelper _dateTimeHelper;
     private readonly ICompanyService _companyService;
+    private readonly ICompanyVendorScheduleService _companyVendorScheduleService;
+    private readonly IProductService _productService;
+    private readonly IShoppingCartService _shoppingCartService;
 
     public CheckoutController_Overriden(
         IDeliveryTimeStorageService deliveryTimeStorageService,
         IDeliveryTimeService deliveryTimeService,
-        
+        ICompanyVendorScheduleService companyVendorScheduleService,
+
         AddressSettings addressSettings, 
         CustomerSettings customerSettings, 
         IAddressAttributeParser addressAttributeParser, 
@@ -101,6 +105,9 @@ public class CheckoutController_Overriden: CheckoutController
         _deliveryTimeService = deliveryTimeService;
         _dateTimeHelper = dateTimeHelper;
         _companyService = companyService;
+        _companyVendorScheduleService = companyVendorScheduleService;
+        _productService = productService;
+        _shoppingCartService = shoppingCartService;
     }
 
     public override async Task<IActionResult> OpcSaveShipping(CheckoutShippingAddressModel model, 
@@ -121,7 +128,26 @@ public class CheckoutController_Overriden: CheckoutController
         {
             throw new Exception("The selected delivery time is no longer available. Please select a new delivery time.");
         }
-        
+
+        var company = await _companyService.GetCompanyByCustomerIdAsync(currentCustomer.Id);
+        if (company != null)
+        {
+            // deliveryTime is stored as company-local wall-clock time (see OpcConfirmOrder), so
+            // its Date is already the company-local calendar date - no timezone conversion needed.
+            var cart = await _shoppingCartService.GetShoppingCartAsync(currentCustomer, ShoppingCartType.ShoppingCart, currentStore.Id);
+            foreach (var item in cart)
+            {
+                var product = await _productService.GetProductByIdAsync(item.ProductId);
+                if (product == null)
+                    continue;
+
+                if (!await _companyVendorScheduleService.IsVendorAvailableAsync(company.Id, product.VendorId, deliveryTime.Value.Date))
+                {
+                    throw new Exception($"'{product.Name}' is not available for delivery on the selected date. Please remove it from your cart or choose a different delivery time.");
+                }
+            }
+        }
+
         return await base.OpcSaveShipping(model, form);
     }
 

--- a/src/Plugins/Nop.Plugin.Company.Company/Migrations/AddVendorScheduleLocalesMigration.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Migrations/AddVendorScheduleLocalesMigration.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentMigrator;
+using Nop.Core.Domain.Localization;
+using Nop.Data;
+using Nop.Data.Migrations;
+
+namespace Nop.Plugin.Company.Company.Migrations
+{
+    /// <summary>
+    /// Seeds the locale string resources used by the new Admin company-vendor schedule
+    /// popup (weekly working days + day-off calendar) and the checkout-time vendor
+    /// availability error. Seeds English defaults plus Armenian translations. Idempotent
+    /// — only inserts keys not already present for a given language, so it is safe on
+    /// install AND upgrade.
+    /// </summary>
+    [NopMigration("2026/08/02 10:05:00:0000000", "Company.AddVendorScheduleLocales")]
+    public class AddVendorScheduleLocalesMigration : Migration
+    {
+        private readonly INopDataProvider _dataProvider;
+
+        public AddVendorScheduleLocalesMigration(INopDataProvider dataProvider)
+        {
+            _dataProvider = dataProvider;
+        }
+
+        public override void Up()
+        {
+            // ResourceName -> (English, Armenian)
+            var resources = new Dictionary<string, (string En, string Hy)>
+            {
+                ["Admin.Companies.Company.Vendors.Schedule"] =
+                    ("Schedule",
+                     "Ժամանակացույց"),
+                ["Admin.Companies.Company.Vendors.Schedule.WorkingDays"] =
+                    ("Working days",
+                     "Աշխատանքային օրեր"),
+                ["Admin.Companies.Company.Vendors.Schedule.WorkingDays.Hint"] =
+                    ("Select the days of week this vendor works for this company. If none are selected, the vendor is available every day.",
+                     "Ընտրեք շաբաթվա օրերը, երբ այս մատակարարը աշխատում է այս ընկերության համար։ Եթե ոչ մեկը ընտրված չէ, մատակարարը հասանելի է ամեն օր։"),
+                ["Admin.Companies.Company.Vendors.Schedule.MarkDayOff"] =
+                    ("Mark day off",
+                     "Նշել որպես ոչ աշխատանքային օր"),
+                ["Admin.Companies.Company.Vendors.Schedule.RestoreDay"] =
+                    ("Restore day",
+                     "Վերականգնել օրը"),
+                ["Admin.Companies.Company.Vendors.Schedule.Saved"] =
+                    ("The schedule has been saved successfully.",
+                     "Ժամանակացույցը հաջողությամբ պահպանվեց։"),
+                ["Order.VendorNotAvailableOnScheduledDate"] =
+                    ("This vendor is not available for delivery on the selected date.",
+                     "Այս մատակարարը հասանելի չէ ընտրված օրով առաքման համար։")
+            };
+
+            var languages = _dataProvider.GetTable<Language>().ToList();
+            var existing = _dataProvider.GetTable<LocaleStringResource>();
+
+            foreach (var lang in languages)
+            {
+                var isArmenian =
+                    string.Equals(lang.UniqueSeoCode, "am", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(lang.UniqueSeoCode, "hy", StringComparison.OrdinalIgnoreCase) ||
+                    (lang.Name != null && lang.Name.IndexOf("Armenian", StringComparison.OrdinalIgnoreCase) >= 0);
+
+                foreach (var kv in resources)
+                {
+                    var present = existing.Any(r => r.LanguageId == lang.Id && r.ResourceName == kv.Key);
+                    if (present)
+                        continue;
+
+                    _dataProvider.InsertEntityAsync(new LocaleStringResource
+                    {
+                        LanguageId = lang.Id,
+                        ResourceName = kv.Key,
+                        ResourceValue = isArmenian ? kv.Value.Hy : kv.Value.En
+                    }).GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        public override void Down()
+        {
+            // No rollback for seeded locale resources.
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Company.Company/Migrations/CompanyVendorScheduleMigration.cs
+++ b/src/Plugins/Nop.Plugin.Company.Company/Migrations/CompanyVendorScheduleMigration.cs
@@ -1,0 +1,51 @@
+using FluentMigrator;
+using Nop.Core.Domain.Companies;
+using Nop.Data.Mapping;
+using Nop.Data.Migrations;
+
+namespace Nop.Plugin.Company.Company.Migrations
+{
+    /// <summary>
+    /// Creates the tables backing the per-company-vendor weekly working-day schedule
+    /// and per-date day-off overrides.
+    /// </summary>
+    [NopMigration("2026/08/02 10:00:00:0000000", "Company.VendorSchedule")]
+    public class CompanyVendorScheduleMigration : Migration
+    {
+        #region Fields
+
+        private readonly IMigrationManager _migrationManager;
+
+        #endregion
+
+        #region Ctor
+
+        public CompanyVendorScheduleMigration(IMigrationManager migrationManager)
+        {
+            _migrationManager = migrationManager;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Collect the UP migration expressions
+        /// </summary>
+        public override void Up()
+        {
+            if (!Schema.Table(NameCompatibilityManager.GetTableName(typeof(CompanyVendorWorkingDay))).Exists())
+                _migrationManager.BuildTable<CompanyVendorWorkingDay>(Create);
+
+            if (!Schema.Table(NameCompatibilityManager.GetTableName(typeof(CompanyVendorDayOff))).Exists())
+                _migrationManager.BuildTable<CompanyVendorDayOff>(Create);
+        }
+
+        public override void Down()
+        {
+            //add the downgrade logic if necessary
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Company.Company/Nop.Plugin.Company.Company.csproj
+++ b/src/Plugins/Nop.Plugin.Company.Company/Nop.Plugin.Company.Company.csproj
@@ -40,6 +40,7 @@
     <None Remove="Views\Edit.cshtml" />
     <None Remove="Views\List.cshtml" />
     <None Remove="Views\VendorAddPopup.cshtml" />
+    <None Remove="Views\VendorSchedulePopup.cshtml" />
     <None Remove="Views\Shared\Components\GlobalDeliveryDatePicker\Default.cshtml" />
     <None Remove="Areas\Admin\Views\Company\**\*.cshtml" />
     <None Remove="Areas\Admin\Views\_ViewImports.cshtml" />
@@ -95,6 +96,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Views\VendorAddPopup.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Views\VendorSchedulePopup.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Views\Shared\Components\GlobalDeliveryDatePicker\Default.cshtml">

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/VendorSchedulePopup.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/VendorSchedulePopup.cshtml
@@ -197,7 +197,7 @@
             $.ajax({
                 url: '@Url.Action("VendorScheduleGetMonth", "Company")',
                 type: 'POST',
-                data: { companyId: companyId, vendorId: vendorId, year: currentYear, month: currentMonth + 1 }
+                data: addAntiForgeryToken({ companyId: companyId, vendorId: vendorId, year: currentYear, month: currentMonth + 1 })
             }).done(function (response) {
                 daysOffSet = {};
                 if (response.success && response.daysOff) {
@@ -271,7 +271,7 @@
                 url: '@Url.Action("VendorScheduleSaveWorkingDays", "Company")',
                 type: 'POST',
                 traditional: true,
-                data: { companyId: companyId, vendorId: vendorId, days: days }
+                data: addAntiForgeryToken({ companyId: companyId, vendorId: vendorId, days: days })
             }).done(function (response) {
                 if (response.success) {
                     $('#working-days-saved-message').show().delay(2000).fadeOut();
@@ -295,7 +295,7 @@
             $.ajax({
                 url: '@Url.Action("VendorScheduleMarkDayOff", "Company")'.replace('VendorScheduleMarkDayOff', action),
                 type: 'POST',
-                data: { companyId: companyId, vendorId: vendorId, date: date }
+                data: addAntiForgeryToken({ companyId: companyId, vendorId: vendorId, date: date })
             }).done(function (response) {
                 if (response.success) {
                     loadMonthAndRender();

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/VendorSchedulePopup.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/VendorSchedulePopup.cshtml
@@ -1,0 +1,308 @@
+@using Nop.Plugin.Company.Company.Areas.Admin.Models
+@model CompanyVendorScheduleModel
+
+@{
+    Layout = "_AdminPopupLayout";
+
+    ViewBag.PageTitle = T("Admin.Companies.Company.Vendors.Schedule").Text;
+}
+
+<div class="content-header clearfix">
+    <h1 class="float-left">
+        @T("Admin.Companies.Company.Vendors.Schedule") - @Model.VendorName
+    </h1>
+    <div class="float-right">
+        &nbsp;
+    </div>
+</div>
+<section class="content">
+    <div class="container-fluid">
+        <div class="form-horizontal">
+            <div class="cards-group">
+                <div class="card card-default card-popup">
+                    <div class="card-body">
+                        <p>@T("Admin.Companies.Company.Vendors.Schedule.WorkingDays.Hint")</p>
+                        <div class="form-group row" id="working-days-checkboxes">
+                            @{
+                                var dayLabels = new[] { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+                            }
+                            @for (var i = 0; i < 7; i++)
+                            {
+                                var isChecked = Model.WorkingDays.Contains(i);
+                                <div class="col-auto">
+                                    <label class="working-day-checkbox">
+                                        <input type="checkbox" class="working-day-input" value="@i" checked="@(isChecked ? "checked" : null)" />
+                                        @dayLabels[i]
+                                    </label>
+                                </div>
+                            }
+                        </div>
+                        <div class="form-group row">
+                            <div class="col-12">
+                                <button type="button" id="save-working-days" class="btn btn-primary">
+                                    <i class="far fa-save"></i>
+                                    @T("Admin.Common.Save")
+                                </button>
+                                <span id="working-days-saved-message" class="text-success" style="display:none; margin-left: 10px;">
+                                    @T("Admin.Companies.Company.Vendors.Schedule.Saved")
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card card-default">
+                    <div class="card-body">
+                        <div class="schedule-calendar-header">
+                            <button type="button" class="btn btn-secondary" id="schedule-prev-month">&lt;</button>
+                            <h4 id="schedule-calendar-title"></h4>
+                            <button type="button" class="btn btn-secondary" id="schedule-next-month">&gt;</button>
+                        </div>
+                        <div class="schedule-calendar-weekdays">
+                            <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
+                        </div>
+                        <div class="schedule-calendar-days" id="schedule-calendar-days"></div>
+                        <div class="schedule-calendar-legend">
+                            <span><i class="schedule-legend-swatch working"></i> Working day</span>
+                            <span><i class="schedule-legend-swatch non-working"></i> Non-working day</span>
+                            <span><i class="schedule-legend-swatch off"></i> Marked off</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<style>
+    .working-day-checkbox {
+        font-weight: normal;
+        margin-right: 4px;
+    }
+
+    .schedule-calendar-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 15px;
+    }
+
+    .schedule-calendar-weekdays {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 2px;
+        margin-bottom: 4px;
+        text-align: center;
+        font-weight: 600;
+    }
+
+    .schedule-calendar-days {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 2px;
+    }
+
+    .schedule-calendar-day {
+        aspect-ratio: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        font-size: 14px;
+        position: relative;
+    }
+
+    .schedule-calendar-day.other-month {
+        color: #dee2e6;
+    }
+
+    .schedule-calendar-day.past {
+        color: #dee2e6;
+    }
+
+    .schedule-calendar-day.working {
+        background: #d4edda;
+        cursor: pointer;
+    }
+
+    .schedule-calendar-day.non-working {
+        background: #f8f9fa;
+    }
+
+    .schedule-calendar-day.off {
+        background: #f8d7da;
+        cursor: pointer;
+    }
+
+    .schedule-calendar-day.working:hover,
+    .schedule-calendar-day.off:hover {
+        opacity: 0.8;
+    }
+
+    .schedule-calendar-legend {
+        margin-top: 15px;
+        display: flex;
+        gap: 15px;
+        font-size: 13px;
+    }
+
+    .schedule-legend-swatch {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        margin-right: 4px;
+    }
+
+    .schedule-legend-swatch.working {
+        background: #d4edda;
+    }
+
+    .schedule-legend-swatch.non-working {
+        background: #f8f9fa;
+        border: 1px solid #dee2e6;
+    }
+
+    .schedule-legend-swatch.off {
+        background: #f8d7da;
+    }
+</style>
+
+<script>
+    $(document).ready(function () {
+        var companyId = @Model.CompanyId;
+        var vendorId = @Model.VendorId;
+        var currentMonth = new Date().getMonth();
+        var currentYear = new Date().getFullYear();
+        var daysOffSet = {}; // "yyyy-MM-dd" -> true
+
+        var monthNames = ["January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"];
+
+        function getWorkingDaySet() {
+            var set = {};
+            $('.working-day-input:checked').each(function () {
+                set[$(this).val()] = true;
+            });
+            return set;
+        }
+
+        function formatDate(date) {
+            return date.getFullYear() + '-' +
+                String(date.getMonth() + 1).padStart(2, '0') + '-' +
+                String(date.getDate()).padStart(2, '0');
+        }
+
+        function loadMonthAndRender() {
+            $.ajax({
+                url: '@Url.Action("VendorScheduleGetMonth", "Company")',
+                type: 'POST',
+                data: { companyId: companyId, vendorId: vendorId, year: currentYear, month: currentMonth + 1 }
+            }).done(function (response) {
+                daysOffSet = {};
+                if (response.success && response.daysOff) {
+                    response.daysOff.forEach(function (d) { daysOffSet[d] = true; });
+                }
+                renderCalendar();
+            });
+        }
+
+        function renderCalendar() {
+            $('#schedule-calendar-title').text(monthNames[currentMonth] + ' ' + currentYear);
+
+            var workingDaySet = getWorkingDaySet();
+            var noPatternConfigured = Object.keys(workingDaySet).length === 0;
+
+            var firstDay = new Date(currentYear, currentMonth, 1);
+            var startDate = new Date(firstDay);
+            startDate.setDate(startDate.getDate() - firstDay.getDay());
+
+            var today = new Date();
+            today.setHours(0, 0, 0, 0);
+
+            var html = '';
+            var date = new Date(startDate);
+            for (var i = 0; i < 42; i++) {
+                var dateStr = formatDate(date);
+                var isCurrentMonth = date.getMonth() === currentMonth;
+                var isPast = date < today;
+                var isWorkingDay = noPatternConfigured || !!workingDaySet[date.getDay()];
+                var isOff = !!daysOffSet[dateStr];
+
+                var cls = 'schedule-calendar-day';
+                if (!isCurrentMonth) cls += ' other-month';
+                else if (isPast) cls += ' past';
+                else if (isOff) cls += ' off';
+                else if (isWorkingDay) cls += ' working';
+                else cls += ' non-working';
+
+                var clickable = isCurrentMonth && !isPast && (isOff || isWorkingDay);
+
+                html += '<div class="' + cls + '"' +
+                    (clickable ? ' data-date="' + dateStr + '" data-off="' + (isOff ? '1' : '0')  + '"' : '') +
+                    '>' + date.getDate() + '</div>';
+
+                date.setDate(date.getDate() + 1);
+            }
+
+            $('#schedule-calendar-days').html(html);
+        }
+
+        $('#schedule-prev-month').click(function () {
+            currentMonth--;
+            if (currentMonth < 0) { currentMonth = 11; currentYear--; }
+            loadMonthAndRender();
+        });
+
+        $('#schedule-next-month').click(function () {
+            currentMonth++;
+            if (currentMonth > 11) { currentMonth = 0; currentYear++; }
+            loadMonthAndRender();
+        });
+
+        $('.working-day-input').change(function () {
+            renderCalendar();
+        });
+
+        $('#save-working-days').click(function () {
+            var days = $('.working-day-input:checked').map(function () { return $(this).val(); }).get();
+
+            $.ajax({
+                url: '@Url.Action("VendorScheduleSaveWorkingDays", "Company")',
+                type: 'POST',
+                traditional: true,
+                data: { companyId: companyId, vendorId: vendorId, days: days }
+            }).done(function (response) {
+                if (response.success) {
+                    $('#working-days-saved-message').show().delay(2000).fadeOut();
+                    renderCalendar();
+                }
+            });
+        });
+
+        $(document).on('click', '.schedule-calendar-day[data-date]', function () {
+            var date = $(this).data('date');
+            var isOff = $(this).data('off') === 1 || $(this).data('off') === '1';
+
+            var action = isOff ? 'VendorScheduleRestoreDay' : 'VendorScheduleMarkDayOff';
+            var confirmMessage = isOff
+                ? 'Restore ' + date + ' for this vendor?'
+                : 'Mark ' + date + ' off for this vendor?';
+
+            if (!confirm(confirmMessage))
+                return;
+
+            $.ajax({
+                url: '@Url.Action("VendorScheduleMarkDayOff", "Company")'.replace('VendorScheduleMarkDayOff', action),
+                type: 'POST',
+                data: { companyId: companyId, vendorId: vendorId, date: date }
+            }).done(function (response) {
+                if (response.success) {
+                    loadMonthAndRender();
+                }
+            });
+        });
+
+        loadMonthAndRender();
+    });
+</script>

--- a/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Vendors.cshtml
+++ b/src/Plugins/Nop.Plugin.Company.Company/Views/_CreateOrUpdate.Vendors.cshtml
@@ -29,6 +29,16 @@
                         ClassName = NopColumnClassDefaults.Button,
                         Render = new RenderButtonView(new DataUrl("~/Admin/Vendor/Edit/", nameof(CompanyVendorModel.VendorId)))
                     },
+                    new ColumnProperty(nameof(CompanyVendorModel.VendorId))
+                    {
+                        Title = T("Admin.Companies.Company.Vendors.Schedule").Text,
+                        Width = "150",
+                        ClassName = NopColumnClassDefaults.Button,
+                        Render = new RenderButtonCustom(NopButtonClassDefaults.Default, T("Admin.Companies.Company.Vendors.Schedule").Text)
+                        {
+                            OnClickFunctionName = "openVendorSchedulePopup"
+                        }
+                    },
                     new ColumnProperty(nameof(CompanyVendorModel.Id))
                     {
                         Title = T("Admin.Common.Delete").Text,
@@ -56,6 +66,11 @@
                     return false;
                 });
             });
+
+            function openVendorSchedulePopup(vendorId) {
+                OpenWindow('@(Url.Action("VendorSchedulePopup", "Company"))?companyId=@(Model.Id)&vendorId=' + vendorId, 900, 800, true);
+                return false;
+            }
         </script>
     </div>
 }

--- a/src/Plugins/Nop.Plugin.Company.Company/plugin.json
+++ b/src/Plugins/Nop.Plugin.Company.Company/plugin.json
@@ -2,7 +2,7 @@
   "Group": "Company",
   "FriendlyName": "Company & Delivery Management",
   "SystemName": "Company.Company",
-  "Version": "2.6",
+  "Version": "2.7",
   "SupportedVersions": [ "4.50" ],
   "Author": "Custom",
   "DisplayOrder": 1,

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
@@ -112,6 +112,7 @@ namespace Nop.Web.Framework.Infrastructure
             services.AddScoped<IBackInStockSubscriptionService, BackInStockSubscriptionService>();
             services.AddScoped<ICategoryService, CategoryService>();
             services.AddScoped<ICompanyService, CompanyService>();
+            services.AddScoped<ICompanyVendorScheduleService, CompanyVendorScheduleService>();
             services.AddScoped<ICompareProductsService, CompareProductsService>();
             services.AddScoped<IRecentlyViewedProductsService, RecentlyViewedProductsService>();
             services.AddScoped<IManufacturerService, ManufacturerService>();

--- a/src/Presentation/Nop.Web/Controllers/Api/Catalog/CatalogApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Catalog/CatalogApiController.cs
@@ -697,6 +697,10 @@ namespace Nop.Web.Controllers.Api.Security
                 .Where(id => id != 0)
                 .ToList();
 
+            DateTime? availabilityDate = DateTime.TryParse(searchModel.DeliveryDate, out var parsedDeliveryDate)
+                ? parsedDeliveryDate
+                : null;
+
             var products = (await _productService.SearchProductsAsync(
                 pageIndex: searchModel.Page ?? 0,
                 pageSize: searchModel.PageSize ?? int.MaxValue,
@@ -706,7 +710,8 @@ namespace Nop.Web.Controllers.Api.Security
                 searchCustomerVendors: true,
                 vendorId: searchModel.VendorId ?? 0,
                 onlyDiscounted: searchModel.BestDeals,
-                orderBy: searchModel.PriceLow == true ? ProductSortingEnum.PriceAsc : searchModel.PriceHigh == true ? ProductSortingEnum.PriceDesc : ProductSortingEnum.Position));
+                orderBy: searchModel.PriceLow == true ? ProductSortingEnum.PriceAsc : searchModel.PriceHigh == true ? ProductSortingEnum.PriceDesc : ProductSortingEnum.Position,
+                availabilityDate: availabilityDate));
 
             if (!products.Any())
             {
@@ -1040,6 +1045,13 @@ namespace Nop.Web.Controllers.Api.Security
             public int? CategoryId { get; set; }
             public int? VendorId { get; set; }
             public int? ProductId { get; set; }
+
+            /// <summary>
+            /// The customer's selected delivery date ("yyyy-MM-dd"), used to hide products from
+            /// vendors that are off/non-working that day. Optional and additive - omitting it
+            /// (older app builds) simply skips this filtering, same as before.
+            /// </summary>
+            public string DeliveryDate { get; set; }
         }
         public partial class ProductReviewsApiModel : BaseEntity
         {

--- a/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
+++ b/src/Presentation/Nop.Web/Controllers/Api/Order/OrderApiController.cs
@@ -62,6 +62,7 @@ namespace Nop.Web.Controllers.Api.Order
         private readonly IOrderTotalCalculationService _orderTotalCalculationService;
         private readonly ICustomerActivityService _customerActivityService;
         private readonly ICompanyService _companyService;
+        private readonly ICompanyVendorScheduleService _companyVendorScheduleService;
         private readonly IProductAttributeParser _productAttributeParser;
         private readonly IProductAttributeService _productAttributeService;
         private readonly ShoppingCartSettings _shoppingCartSettings;
@@ -97,6 +98,7 @@ namespace Nop.Web.Controllers.Api.Order
             IOrderTotalCalculationService orderTotalCalculationService,
             ICustomerActivityService customerActivityService,
             ICompanyService companyService,
+            ICompanyVendorScheduleService companyVendorScheduleService,
             IProductAttributeParser productAttributeParser,
             ShoppingCartSettings shoppingCartSettings, 
             IProductAttributeService productAttributeService, 
@@ -127,6 +129,7 @@ namespace Nop.Web.Controllers.Api.Order
             _orderTotalCalculationService = orderTotalCalculationService;
             _customerActivityService = customerActivityService;
             _companyService = companyService;
+            _companyVendorScheduleService = companyVendorScheduleService;
             _productAttributeParser = productAttributeParser;
             _shoppingCartSettings = shoppingCartSettings;
             _productAttributeService = productAttributeService;
@@ -278,7 +281,13 @@ namespace Nop.Web.Controllers.Api.Order
                 var scheduledDateUTC = await ConvertCustomerLocalTimeToUTCAsync(
                     customer,
                     productOrderRequestApiModel.ScheduleDate);
-                
+
+                var company = await _companyService.GetCompanyByCustomerIdAsync(customer.Id);
+                var companyLocalScheduledDate = company == null
+                    ? scheduledDateUTC.Date
+                    : _dateTimeHelper.ConvertToUserTime(scheduledDateUTC, TimeZoneInfo.Utc,
+                        TZConvert.GetTimeZoneInfo(company.TimeZone)).Date;
+
                 foreach (var currentProductOrder in productOrderRequestApiModel.Products)
                 {
                     try
@@ -288,11 +297,24 @@ namespace Nop.Web.Controllers.Api.Order
                         {
                             errorList.Add(new CartErrorModel
                             {
-                                Success = false, 
+                                Success = false,
                                 Id = currentProductOrder.ProductId,
                                 Message = "No product found"
                             });
-                        
+
+                            continue;
+                        }
+
+                        if (company != null &&
+                            !await _companyVendorScheduleService.IsVendorAvailableAsync(company.Id, product.VendorId, companyLocalScheduledDate))
+                        {
+                            errorList.Add(new CartErrorModel
+                            {
+                                Success = false,
+                                Id = currentProductOrder.ProductId,
+                                Message = await _localizationService.GetResourceAsync("Order.VendorNotAvailableOnScheduledDate")
+                            });
+
                             continue;
                         }
 

--- a/src/Presentation/Nop.Web/Controllers/CatalogController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CatalogController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
@@ -330,13 +331,20 @@ namespace Nop.Web.Controllers
             var productNumber = _catalogSettings.ProductSearchAutoCompleteNumberOfProducts > 0 ?
                 _catalogSettings.ProductSearchAutoCompleteNumberOfProducts : 10;
 
+            // Reads the same generic attribute Nop.Plugin.Company.Company.Services.
+            // DeliveryTimeStorageService writes to - this core controller can't reference that
+            // plugin-defined service directly.
+            var selectedDeliveryDate = await _genericAttributeService.GetAttributeAsync<DateTime?>(
+                await _workContext.GetCurrentCustomerAsync(), "SELECTED_DELIVERY_TIME_KEY", (await _storeContext.GetCurrentStoreAsync()).Id);
+
             var products = await _productService.SearchProductsAsync(0,
                 storeId: (await _storeContext.GetCurrentStoreAsync()).Id,
                 keywords: term,
                 languageId: (await _workContext.GetWorkingLanguageAsync()).Id,
                 visibleIndividuallyOnly: true,
                 pageSize: productNumber,
-                searchCustomerVendors: true);
+                searchCustomerVendors: true,
+                availabilityDate: selectedDeliveryDate);
 
             var showLinkToResultSearch = _catalogSettings.ShowLinkToAllResultInSearchAutoComplete && (products.TotalCount > productNumber);
 

--- a/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
@@ -65,6 +65,7 @@ namespace Nop.Web.Factories
         private readonly ISpecificationAttributeService _specificationAttributeService;
         private readonly IStaticCacheManager _staticCacheManager;
         private readonly IStoreContext _storeContext;
+        private readonly IGenericAttributeService _genericAttributeService;
         private readonly ITopicService _topicService;
         private readonly IUrlHelperFactory _urlHelperFactory;
         private readonly IUrlRecordService _urlRecordService;
@@ -110,8 +111,10 @@ namespace Nop.Web.Factories
             IWorkContext workContext,
             MediaSettings mediaSettings,
             VendorSettings vendorSettings,
-            ISettingService settingService)
+            ISettingService settingService,
+            IGenericAttributeService genericAttributeService)
         {
+            _genericAttributeService = genericAttributeService;
             _blogSettings = blogSettings;
             _catalogSettings = catalogSettings;
             _displayDefaultMenuItemSettings = displayDefaultMenuItemSettings;
@@ -149,6 +152,22 @@ namespace Nop.Web.Factories
         #endregion
 
         #region Utilities
+
+        /// <summary>
+        /// Gets the customer's currently selected delivery date, for filtering out products from
+        /// vendors that are off/non-working that day. Reads the same generic attribute the
+        /// Company plugin's IDeliveryTimeStorageService uses (this core factory can't reference
+        /// that plugin-defined service directly - see Nop.Plugin.Company.Company.Services.
+        /// DeliveryTimeStorageService for the counterpart write path). Returns null if the
+        /// customer hasn't selected a delivery time yet, in which case callers should not filter.
+        /// </summary>
+        protected virtual async Task<DateTime?> GetSelectedDeliveryDateAsync()
+        {
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var storeId = (await _storeContext.GetCurrentStoreAsync()).Id;
+
+            return await _genericAttributeService.GetAttributeAsync<DateTime?>(customer, "SELECTED_DELIVERY_TIME_KEY", storeId);
+        }
 
         protected virtual CategorySimpleModel GetCategorySimpleModel(XElement elem)
         {
@@ -788,7 +807,8 @@ namespace Nop.Web.Factories
                 manufacturerIds: command.ManufacturerIds,
                 filteredSpecOptions: filteredSpecs,
                 orderBy: (ProductSortingEnum)command.OrderBy,
-                searchCustomerVendors: true);
+                searchCustomerVendors: true,
+                availabilityDate: await GetSelectedDeliveryDateAsync());
 
             var isFiltering = filterableOptions.Any() || selectedPriceRange?.From is not null;
             await PrepareCatalogProductsAsync(model, products, isFiltering);
@@ -837,7 +857,7 @@ namespace Nop.Web.Factories
             var allCategories = await _categoryService.GetAllCategoriesAsync(storeId: (await _storeContext.GetCurrentStoreAsync()).Id);
             if (filterVendorCategories)
             {
-                var productIds = (await _productService.SearchProductsAsync(searchCustomerVendors: true))
+                var productIds = (await _productService.SearchProductsAsync(searchCustomerVendors: true, availabilityDate: await GetSelectedDeliveryDateAsync()))
                     .Select(p => p.Id).ToArray();
                 var categoryIds = (await _categoryService.GetProductCategoryIdsAsync(productIds))
                     .SelectMany(pc => pc.Value).Distinct().ToArray();
@@ -1057,7 +1077,8 @@ namespace Nop.Web.Factories
                 priceMax: selectedPriceRange?.To,
                 filteredSpecOptions: filteredSpecs,
                 orderBy: (ProductSortingEnum)command.OrderBy,
-                searchCustomerVendors: true);
+                searchCustomerVendors: true,
+                availabilityDate: await GetSelectedDeliveryDateAsync());
 
             var isFiltering = filterableOptions.Any() || selectedPriceRange?.From is not null;
             await PrepareCatalogProductsAsync(model, products, isFiltering);
@@ -1301,7 +1322,8 @@ namespace Nop.Web.Factories
                 storeId: (await _storeContext.GetCurrentStoreAsync()).Id,
                 visibleIndividuallyOnly: true,
                 orderBy: (ProductSortingEnum)command.OrderBy,
-                searchCustomerVendors: true);
+                searchCustomerVendors: true,
+                availabilityDate: await GetSelectedDeliveryDateAsync());
 
             var isFiltering = selectedPriceRange?.From is not null;
             await PrepareCatalogProductsAsync(model, products, isFiltering);
@@ -1798,7 +1820,8 @@ namespace Nop.Web.Factories
                         languageId: workingLanguage.Id,
                         orderBy: (ProductSortingEnum)command.OrderBy,
                         vendorId: vendorId,
-                        searchCustomerVendors: true);
+                        searchCustomerVendors: true,
+                        availabilityDate: await GetSelectedDeliveryDateAsync());
 
                     //search term statistics
                     if (!string.IsNullOrEmpty(searchTerms))


### PR DESCRIPTION
## Summary
- New admin calendar on the Company edit page's Vendors tab: configure a weekly working-day pattern per company-vendor pair, and mark/restore individual dates off (with history via CreatedOnUtc/RestoredOnUtc).
- Enforced at order time on both surfaces: mobile `check-products` and website checkout (`OpcSaveShipping`) reject cart items whose vendor is off/non-working on the selected delivery date.
- Catalog browsing (website category/manufacturer/vendor/search pages + autocomplete, and mobile `product-search`) hides products from vendors unavailable on the customer's currently-selected delivery date - not "today", so a vendor closed only on a specific weekday doesn't wrongly disappear for someone ordering a different day.
- Fixed a pre-existing bug in `CheckoutController_Overriden.OpcSaveShipping`: all three validation checks threw raw exceptions before reaching the base method's own try/catch, producing a raw 500 error page instead of the site's normal one-page-checkout JSON error banner.
- Mobile API changes are additive/backward-compatible: `product-search` gained an optional `DeliveryDate` param, ignored entirely when absent so older app builds are unaffected.

## Test plan
- [x] Verified end-to-end on dev.mysnacks.shop: admin calendar save/mark-off/restore round-trip, mobile `check-products` block + website checkout block (JSON error, no order created), catalog hiding on both website (`GetVendorProducts`) and mobile (`product-search` with/without `DeliveryDate`) for a marked-off vendor, confirmed products reappear on an available date and with no `DeliveryDate` param at all.
- [x] All 4 commits built successfully in CI (Docker Image CI workflow).
- [x] Local `dotnet build` compiles the solution cleanly (0 compiler errors); only the local post-build plugin-cleanup step fails due to an unrelated SDK version drift in this sandbox, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)